### PR TITLE
[nrf temphack]: Adding configurable BL2 config

### DIFF
--- a/trusted-firmware-m/bl2/CMakeLists.txt
+++ b/trusted-firmware-m/bl2/CMakeLists.txt
@@ -60,7 +60,7 @@ target_compile_definitions(bl2_mbedcrypto_config
     INTERFACE
         $<$<STREQUAL:${MCUBOOT_SIGNATURE_TYPE},RSA>:MCUBOOT_SIGN_RSA>
         $<$<STREQUAL:${MCUBOOT_SIGNATURE_TYPE},RSA>:MCUBOOT_SIGN_RSA_LEN=${MCUBOOT_SIGNATURE_KEY_LEN}>
-        MBEDTLS_CONFIG_FILE="$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ext/mcuboot/config/mcuboot-mbedtls-cfg.h>"
+        MBEDTLS_CONFIG_FILE="${MCUBOOT_MBEDCRYPTO_CONFIG_PATH}"
         # Workaround for https://github.com/ARMmbed/mbedtls/issues/1077
         $<$<OR:$<STREQUAL:${CMAKE_SYSTEM_ARCHITECTURE},armv8-m.base>,$<STREQUAL:${CMAKE_SYSTEM_ARCHITECTURE},armv6-m>>:MULADDC_CANNOT_USE_R7>
 )

--- a/trusted-firmware-m/config/config_default.cmake
+++ b/trusted-firmware-m/config/config_default.cmake
@@ -72,7 +72,7 @@ set(MCUBOOT_SECURITY_COUNTER_NS         "auto"      CACHE STRING    "Security co
 set(MCUBOOT_S_IMAGE_MIN_VER             0.0.0+0     CACHE STRING    "Minimum version of secure image required by the non-secure image for upgrade to this non-secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
 set(MCUBOOT_NS_IMAGE_MIN_VER            0.0.0+0     CACHE STRING    "Minimum version of non-secure image required by the secure image for upgrade to this secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
 
-set(MCUBOOT_MBEDCRYPTO_CONFIG_PATH      "${CMAKE_SOURCE_DIR}/bl2/ext/mcuboot/config/mcuboot-mbedtls-cfg.h" CACHE PATH "Config to use for MCUboot")
+set(MCUBOOT_MBEDCRYPTO_CONFIG_PATH      "${CMAKE_SOURCE_DIR}/bl2/ext/mcuboot/config/mcuboot-mbedtls-cfg.h" CACHE STRING "Config to use for MCUboot")
 
 ############################ Platform ##########################################
 
@@ -165,7 +165,7 @@ set(MBEDCRYPTO_PATH                     "DOWNLOAD"  CACHE PATH      "Path to Mbe
 set(MBEDCRYPTO_VERSION                  "mbedtls-2.25.0" CACHE STRING "The version of Mbed Crypto to use")
 set(MBEDCRYPTO_GIT_REMOTE               "https://github.com/ARMmbed/mbedtls.git" CACHE STRING "The URL (or path) to retrieve MbedTLS from.")
 set(MBEDCRYPTO_BUILD_TYPE               "${CMAKE_BUILD_TYPE}" CACHE STRING "Build type of Mbed Crypto library")
-set(TFM_MBEDCRYPTO_CONFIG_PATH          "${CMAKE_SOURCE_DIR}/lib/ext/mbedcrypto/mbedcrypto_config/tfm_mbedcrypto_config_default.h" CACHE PATH "Config to use for Mbed Crypto")
+set(TFM_MBEDCRYPTO_CONFIG_PATH          "${CMAKE_SOURCE_DIR}/lib/ext/mbedcrypto/mbedcrypto_config/tfm_mbedcrypto_config_default.h" CACHE STRING "Config to use for Mbed Crypto")
 set(TFM_MBEDCRYPTO_PLATFORM_EXTRA_CONFIG_PATH "" CACHE PATH "Config to append to standard Mbed Crypto config, used by platforms to cnfigure feature support")
 
 set(TFM_TEST_REPO_PATH                  "DOWNLOAD"  CACHE PATH      "Path to TFM-TEST repo (or DOWNLOAD to fetch automatically")

--- a/trusted-firmware-m/config/config_default.cmake
+++ b/trusted-firmware-m/config/config_default.cmake
@@ -72,6 +72,8 @@ set(MCUBOOT_SECURITY_COUNTER_NS         "auto"      CACHE STRING    "Security co
 set(MCUBOOT_S_IMAGE_MIN_VER             0.0.0+0     CACHE STRING    "Minimum version of secure image required by the non-secure image for upgrade to this non-secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
 set(MCUBOOT_NS_IMAGE_MIN_VER            0.0.0+0     CACHE STRING    "Minimum version of non-secure image required by the secure image for upgrade to this secure image. If MCUBOOT_IMAGE_NUMBER == 1 this option has no effect")
 
+set(MCUBOOT_MBEDCRYPTO_CONFIG_PATH      "${CMAKE_SOURCE_DIR}/bl2/ext/mcuboot/config/mcuboot-mbedtls-cfg.h" CACHE PATH "Config to use for MCUboot")
+
 ############################ Platform ##########################################
 
 set(TFM_MULTI_CORE_TOPOLOGY             OFF         CACHE BOOL      "Whether to build for a dual-cpu architecture")

--- a/trusted-firmware-m/interface/include/psa/crypto_extra.h
+++ b/trusted-firmware-m/interface/include/psa/crypto_extra.h
@@ -55,6 +55,92 @@ extern "C" {
  */
 #define PSA_KEY_TYPE_DSA_KEY_PAIR                    ((psa_key_type_t)0x7002)
 
+#if defined(MBEDTLS_ECP_C)
+#include <mbedtls/ecp.h>
+
+/** Convert an ECC curve identifier from the Mbed TLS encoding to PSA.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param grpid         An Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \param[out] bits     On success, the bit size of the curve.
+ *
+ * \return              The corresponding PSA elliptic curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \return              \c 0 on failure (\p grpid is not recognized).
+ */
+static inline psa_ecc_family_t mbedtls_ecc_group_to_psa( mbedtls_ecp_group_id grpid,
+                                                        size_t *bits )
+{
+    switch( grpid )
+    {
+        case MBEDTLS_ECP_DP_SECP192R1:
+            *bits = 192;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP224R1:
+            *bits = 224;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP256R1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP384R1:
+            *bits = 384;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_SECP521R1:
+            *bits = 521;
+            return( PSA_ECC_FAMILY_SECP_R1 );
+        case MBEDTLS_ECP_DP_BP256R1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP384R1:
+            *bits = 384;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_BP512R1:
+            *bits = 512;
+            return( PSA_ECC_FAMILY_BRAINPOOL_P_R1 );
+        case MBEDTLS_ECP_DP_CURVE25519:
+            *bits = 255;
+            return( PSA_ECC_FAMILY_MONTGOMERY );
+        case MBEDTLS_ECP_DP_SECP192K1:
+            *bits = 192;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP224K1:
+            *bits = 224;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_SECP256K1:
+            *bits = 256;
+            return( PSA_ECC_FAMILY_SECP_K1 );
+        case MBEDTLS_ECP_DP_CURVE448:
+            *bits = 448;
+            return( PSA_ECC_FAMILY_MONTGOMERY );
+        default:
+            *bits = 0;
+            return( 0 );
+    }
+}
+
+/** Convert an ECC curve identifier from the PSA encoding to Mbed TLS.
+ *
+ * \note This function is provided solely for the convenience of
+ *       Mbed TLS and may be removed at any time without notice.
+ *
+ * \param curve         A PSA elliptic curve identifier
+ *                      (`PSA_ECC_FAMILY_xxx`).
+ * \param byte_length   The byte-length of a private key on \p curve.
+ *
+ * \return              The corresponding Mbed TLS elliptic curve identifier
+ *                      (`MBEDTLS_ECP_DP_xxx`).
+ * \return              #MBEDTLS_ECP_DP_NONE if \c curve is not recognized.
+ * \return              #MBEDTLS_ECP_DP_NONE if \p byte_length is not
+ *                      correct for \p curve.
+ */
+mbedtls_ecp_group_id mbedtls_ecc_group_of_psa( psa_ecc_family_t curve,
+                                               size_t byte_length );
+#endif /* MBEDTLS_ECP_C */
+
+
 /**@}*/
 
 #ifdef __cplusplus

--- a/trusted-firmware-m/interface/include/psa/crypto_types.h
+++ b/trusted-firmware-m/interface/include/psa/crypto_types.h
@@ -221,6 +221,23 @@ typedef uint32_t psa_key_id_t;
 
 /**@}*/
 
+#if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
+typedef psa_key_id_t mbedtls_svc_key_id_t;
+
+#else /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
+/* Implementation-specific: The Mbed Cryptography library can be built as
+ * part of a multi-client service that exposes the PSA Cryptograpy API in each
+ * client and encodes the client identity in the key identifier argument of
+ * functions such as psa_open_key().
+ */
+typedef struct
+{
+    psa_key_id_t key_id;
+    mbedtls_key_owner_id_t owner;
+} mbedtls_svc_key_id_t;
+
+#endif /* !MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
+
 /** \defgroup policy Key policies
  * @{
  */

--- a/trusted-firmware-m/interface/include/psa/crypto_values.h
+++ b/trusted-firmware-m/interface/include/psa/crypto_values.h
@@ -1653,6 +1653,95 @@
 
 /**@}*/
 
+#if !defined(MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER)
+
+#define MBEDTLS_SVC_KEY_ID_INIT ( (psa_key_id_t)0 )
+#define MBEDTLS_SVC_KEY_ID_GET_KEY_ID( id ) ( id )
+#define MBEDTLS_SVC_KEY_ID_GET_OWNER_ID( id ) ( 0 )
+
+/** Utility to initialize a key identifier at runtime.
+ *
+ * \param unused  Unused parameter.
+ * \param key_id  Identifier of the key.
+ */
+static inline mbedtls_svc_key_id_t mbedtls_svc_key_id_make(
+    unsigned int unused, psa_key_id_t key_id )
+{
+    (void)unused;
+
+    return( key_id );
+}
+
+/** Compare two key identifiers.
+ *
+ * \param id1 First key identifier.
+ * \param id2 Second key identifier.
+ *
+ * \return Non-zero if the two key identifier are equal, zero otherwise.
+ */
+static inline int mbedtls_svc_key_id_equal( mbedtls_svc_key_id_t id1,
+                                            mbedtls_svc_key_id_t id2 )
+{
+    return( id1 == id2 );
+}
+
+/** Check whether a key identifier is null.
+ *
+ * \param key Key identifier.
+ *
+ * \return Non-zero if the key identifier is null, zero otherwise.
+ */
+static inline int mbedtls_svc_key_id_is_null( mbedtls_svc_key_id_t key )
+{
+    return( key == 0 );
+}
+
+#else /* MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
+
+#define MBEDTLS_SVC_KEY_ID_INIT ( (mbedtls_svc_key_id_t){ 0, 0 } )
+#define MBEDTLS_SVC_KEY_ID_GET_KEY_ID( id ) ( ( id ).key_id )
+#define MBEDTLS_SVC_KEY_ID_GET_OWNER_ID( id ) ( ( id ).owner )
+
+/** Utility to initialize a key identifier at runtime.
+ *
+ * \param owner_id Identifier of the key owner.
+ * \param key_id   Identifier of the key.
+ */
+static inline mbedtls_svc_key_id_t mbedtls_svc_key_id_make(
+    mbedtls_key_owner_id_t owner_id, psa_key_id_t key_id )
+{
+    return( (mbedtls_svc_key_id_t){ .key_id = key_id,
+                                    .owner = owner_id } );
+}
+
+/** Compare two key identifiers.
+ *
+ * \param id1 First key identifier.
+ * \param id2 Second key identifier.
+ *
+ * \return Non-zero if the two key identifier are equal, zero otherwise.
+ */
+static inline int mbedtls_svc_key_id_equal( mbedtls_svc_key_id_t id1,
+                                            mbedtls_svc_key_id_t id2 )
+{
+    return( ( id1.key_id == id2.key_id ) &&
+            mbedtls_key_owner_id_equal( id1.owner, id2.owner ) );
+}
+
+/** Check whether a key identifier is null.
+ *
+ * \param key Key identifier.
+ *
+ * \return Non-zero if the key identifier is null, zero otherwise.
+ */
+static inline int mbedtls_svc_key_id_is_null( mbedtls_svc_key_id_t key )
+{
+    return( ( key.key_id == 0 ) && ( key.owner == 0 ) );
+}
+
+#endif /* !MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER */
+
+
 /** \defgroup policy Key policies
  * @{
  */


### PR DESCRIPTION
-Changing from static definition to configurable CMake variable
 called MCUBOOT_MBEDCRYPTO_CONFIG_PATH

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>