### PR TITLE
[nrf_fromlist] protected_storage: Enable non static key labels

### DIFF
--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.c
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.c
@@ -35,7 +35,6 @@
  */
 typedef char PS_ERROR_NOT_AEAD_ALG[(PSA_ALG_IS_AEAD(PS_CRYPTO_ALG)) ? 1 : -1];
 
-static const uint8_t ps_key_label[] = "storage_key";
 static psa_key_id_t ps_key;
 static uint8_t ps_crypto_iv_buf[PS_IV_LEN_BYTES];
 
@@ -47,11 +46,15 @@ psa_status_t ps_crypto_init(void)
     return PSA_SUCCESS;
 }
 
-psa_status_t ps_crypto_setkey(void)
+psa_status_t ps_crypto_setkey(const uint8_t *key_label, size_t key_label_len)
 {
     psa_status_t status;
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
     psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
+
+    if (key_label_len == 0 || key_label == NULL) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    };
 
     /* Set the key attributes for the storage key */
     psa_set_key_usage_flags(&attributes, PS_KEY_USAGE);
@@ -67,8 +70,8 @@ psa_status_t ps_crypto_setkey(void)
 
     /* Supply the PS key label as an input to the key derivation */
     status = psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_LABEL,
-                                            ps_key_label,
-                                            sizeof(ps_key_label));
+                                            key_label,
+                                            key_label_len);
     if (status != PSA_SUCCESS) {
         goto err_release_op;
     }

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.h
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.h
@@ -20,6 +20,10 @@ extern "C" {
 #define PS_KEY_LEN_BYTES  16
 #define PS_TAG_LEN_BYTES  16
 #define PS_IV_LEN_BYTES   12
+/* The key label consists of the uid + client_id, thus the length of it is:
+ * sizeof(psa_storage_uid_t) + sizeof(int32_t).
+ */
+#define PS_KEY_LABEL_LEN_BYTES 12
 
 /* Union containing crypto policy implementations. The ref member provides the
  * reference implementation. Further members can be added to the union to
@@ -27,6 +31,7 @@ extern "C" {
  */
 union ps_crypto_t {
     struct {
+        uint8_t key_label[PS_KEY_LABEL_LEN_BYTES]; /*!< Key label value */
         uint8_t tag[PS_TAG_LEN_BYTES]; /*!< MAC value of AEAD object */
         uint8_t iv[PS_IV_LEN_BYTES];   /*!< IV value of AEAD object */
     } ref;
@@ -42,9 +47,12 @@ psa_status_t ps_crypto_init(void);
 /**
  * \brief Sets the key to use for crypto operations for the current client.
  *
+ * \param[in]     key_label       Pointer to the key label
+ * \param[in]     key_label_len   Length of the key label
+ *
  * \return Returns values as described in \ref psa_status_t
  */
-psa_status_t ps_crypto_setkey(void);
+psa_status_t ps_crypto_setkey(const uint8_t *key_label, size_t key_label_len);
 
 /**
  * \brief Destroys the transient key used for crypto operations.

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_encrypted_object.c
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_encrypted_object.c
@@ -53,7 +53,8 @@ static psa_status_t ps_object_auth_decrypt(uint32_t fid,
     uint8_t *p_obj_data = (uint8_t *)&obj->header.info;
     size_t out_len;
 
-    err = ps_crypto_setkey();
+    err = ps_crypto_setkey(obj->header.crypto.ref.key_label,
+                           sizeof(obj->header.crypto.ref.key_label));
     if (err != PSA_SUCCESS) {
         return err;
     }
@@ -100,7 +101,8 @@ static psa_status_t ps_object_auth_encrypt(uint32_t fid,
     uint8_t *p_obj_data = (uint8_t *)&obj->header.info;
     size_t out_len;
 
-    err = ps_crypto_setkey();
+    err = ps_crypto_setkey(obj->header.crypto.ref.key_label,
+                           sizeof(obj->header.crypto.ref.key_label));
     if (err != PSA_SUCCESS) {
         return err;
     }

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_object_system.c
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_object_system.c
@@ -188,6 +188,13 @@ psa_status_t ps_object_read(psa_storage_uid_t uid, int32_t client_id,
 
     /* Read object */
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
     err = ps_encrypted_object_read(g_obj_tbl_info.fid, &g_ps_object);
 #else
     /* Read object header */
@@ -243,6 +250,14 @@ psa_status_t ps_object_create(psa_storage_uid_t uid, int32_t client_id,
     if (err == PSA_SUCCESS) {
 #ifdef PS_ENCRYPTION
         /* Read the object */
+        err = ps_utils_encode_key_label(uid,
+                            client_id,
+                            g_ps_object.header.crypto.ref.key_label,
+                            sizeof(g_ps_object.header.crypto.ref.key_label));
+        if (err != PSA_SUCCESS) {
+            goto clear_data_and_return;
+        }
+
         err = ps_encrypted_object_read(g_obj_tbl_info.fid, &g_ps_object);
 #else
         /* Read the object header */
@@ -294,6 +309,14 @@ psa_status_t ps_object_create(psa_storage_uid_t uid, int32_t client_id,
     }
 
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
+
     err = ps_encrypted_object_write(g_obj_tbl_info.fid, &g_ps_object);
 #else
     wrt_size = PS_OBJECT_SIZE(g_ps_object.header.info.current_size);
@@ -354,6 +377,14 @@ psa_status_t ps_object_write(psa_storage_uid_t uid, int32_t client_id,
 
     /* Read the object */
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
+
     err = ps_encrypted_object_read(g_obj_tbl_info.fid, &g_ps_object);
 #else
     err = ps_read_object(READ_ALL_OBJECT);
@@ -404,6 +435,14 @@ psa_status_t ps_object_write(psa_storage_uid_t uid, int32_t client_id,
     }
 
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
+
     err = ps_encrypted_object_write(g_obj_tbl_info.fid, &g_ps_object);
 #else
     wrt_size = PS_OBJECT_SIZE(g_ps_object.header.info.current_size);
@@ -453,6 +492,14 @@ psa_status_t ps_object_get_info(psa_storage_uid_t uid, int32_t client_id,
     }
 
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
+
     err = ps_encrypted_object_read(g_obj_tbl_info.fid, &g_ps_object);
 #else
     err = ps_read_object(READ_HEADER_ONLY);
@@ -486,6 +533,14 @@ psa_status_t ps_object_delete(psa_storage_uid_t uid, int32_t client_id)
     }
 
 #ifdef PS_ENCRYPTION
+    err = ps_utils_encode_key_label(uid,
+                        client_id,
+                        g_ps_object.header.crypto.ref.key_label,
+                        sizeof(g_ps_object.header.crypto.ref.key_label));
+    if (err != PSA_SUCCESS) {
+        goto clear_data_and_return;
+    }
+
     err = ps_encrypted_object_read(g_obj_tbl_info.fid, &g_ps_object);
 #else
     err = ps_read_object(READ_HEADER_ONLY);

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_object_table.c
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_object_table.c
@@ -71,6 +71,8 @@ struct ps_obj_table_t {
                                                              */
 };
 
+static uint8_t ps_table_key_label[] = "table_key_label";
+
 /* Object table indexes */
 #define PS_OBJ_TABLE_IDX_0 0
 #define PS_OBJ_TABLE_IDX_1 1
@@ -546,7 +548,7 @@ static psa_status_t ps_object_table_save_table(
 
 #ifdef PS_ENCRYPTION
     /* Set object table key */
-    err = ps_crypto_setkey();
+    err = ps_crypto_setkey(ps_table_key_label, sizeof(ps_table_key_label));
     if (err != PSA_SUCCESS) {
         return err;
     }
@@ -844,7 +846,7 @@ psa_status_t ps_object_table_init(uint8_t *obj_data)
 
 #ifdef PS_ENCRYPTION
     /* Set object table key */
-    err = ps_crypto_setkey();
+    err = ps_crypto_setkey(ps_table_key_label, sizeof(ps_table_key_label));
     if (err != PSA_SUCCESS) {
         return err;
     }

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_utils.c
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_utils.c
@@ -6,6 +6,7 @@
  */
 
 #include "ps_utils.h"
+#include "tfm_memory_utils.h"
 
 psa_status_t ps_utils_check_contained_in(uint32_t superset_size,
                                          uint32_t subset_offset,
@@ -26,3 +27,26 @@ psa_status_t ps_utils_check_contained_in(uint32_t superset_size,
 
     return PSA_SUCCESS;
 }
+
+#ifdef PS_ENCRYPTION
+psa_status_t ps_utils_encode_key_label(psa_storage_uid_t uid,
+                                       int32_t client_id,
+                                       uint8_t *buff,
+                                       size_t buff_len)
+{
+
+    if (buff_len < (sizeof(client_id) + sizeof(uid))) {
+        return PSA_ERROR_BUFFER_TOO_SMALL;
+    }
+
+    if (buff == NULL) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    tfm_memset(buff, 0x0, buff_len);
+    tfm_memcpy(buff, &client_id, sizeof(client_id));
+    tfm_memcpy(buff + sizeof(client_id), &uid, sizeof(uid));
+
+    return PSA_SUCCESS;
+}
+#endif

--- a/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_utils.h
+++ b/trusted-firmware-m/secure_fw/partitions/protected_storage/ps_utils.h
@@ -62,6 +62,27 @@ psa_status_t ps_utils_check_contained_in(uint32_t superset_size,
                                          uint32_t subset_offset,
                                          uint32_t subset_size);
 
+
+#ifdef PS_ENCRYPTION
+/**
+ * \brief Fills the uint8_t buffer with the client_id and the uid
+ *
+ * \param[in]  uid            The data identifier
+ * \param[in]  client_id      Client id of the partition
+ * \param[out] buff           The output buffer
+ * \param[in]  buff_len       Length of the output buffer in bytes
+ *
+ * \retval PSA_SUCCESS                  Buffer filled successfully
+ * \retval PSA_ERROR_INVALID_ARGUMENT   The buffer pointer is NULL
+ * \retval PSA_ERROR_BUFFER_TOO_SMALL   The buffer cannot fit the client_id + uid
+ *
+ */
+psa_status_t ps_utils_encode_key_label(psa_storage_uid_t uid,
+                                       int32_t client_id,
+                                       uint8_t *buff,
+                                       size_t buff_len);
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
-Adds non static key labels for the key derivation
-Client id is used as the label
-The ps_table still has a static label

Upstream PR: [pull/10198](https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/10198)

Ref: NCSDK-9028

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>