### PR TITLE
[nrf fromlist]: Enable CCM as default for protected storage

### DIFF
--- a/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
+++ b/trusted-firmware-m/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
@@ -9,3 +9,4 @@
 set(SECURE_UART1                        ON         CACHE BOOL      "Enable secure UART1")
 set(PSA_API_TEST_TARGET                 "nrf"      CACHE STRING    "PSA API test target")
 set(ITS_NUM_ASSETS                      "5"        CACHE STRING    "The maximum number of assets to be stored in the Internal Trusted Storage area")
+set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_CCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")


### PR DESCRIPTION
[Upstream PR](https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/10125)

-Enables AES-CCM as the default AEAD algorithm
 for nRF9160 and nRF5340

Ref: NCSDK-9006
Manifest PR: [pull/4645](https://github.com/nrfconnect/sdk-nrf/pull/4645)

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>