### PR TITLE
[noup] TF-M: Changing from mbedtls to mbedcrypto

### DIFF
--- a/platform/CMakeLists.txt
+++ b/platform/CMakeLists.txt
@@ -74,7 +74,7 @@ target_link_libraries(platform_s
         tfm_arch
         tfm_partition_defs
         $<$<BOOL:${PLATFORM_DEFAULT_ATTEST_HAL}>:tfm_sprt>
-        $<$<AND:$<BOOL:${TFM_PARTITION_CRYPTO}>,$<BOOL:${PLATFORM_DEFAULT_CRYPTO_KEYS}>>:crypto_service_mbedtls>
+        $<$<AND:$<BOOL:${TFM_PARTITION_CRYPTO}>,$<BOOL:${PLATFORM_DEFAULT_CRYPTO_KEYS}>>:crypto_service_mbedcrypto>
 )
 
 target_compile_definitions(platform_s

--- a/secure_fw/partitions/crypto/CMakeLists.txt
+++ b/secure_fw/partitions/crypto/CMakeLists.txt
@@ -199,13 +199,3 @@ target_link_libraries(crypto_service_mbedcrypto
     PUBLIC
         crypto_service_mbedcrypto_config
 )
-
-target_link_libraries(crypto_service_mbedtls
-    PRIVATE
-        platform_s
-)
-
-target_link_libraries(crypto_service_mbedx509
-    PRIVATE
-        platform_s
-)


### PR DESCRIPTION
-Removing references for crypto_service_mbedtls and
 crypto_service_mbedx509
-linking only with crypto_service_mbedcrypto

ref: NCSDK-13530

Signed-off-by: Frank Audun Kvamtrø <frank.kvamtro@nordicsemi.no>