### PR TITLE
[nrf fromtree] platform: lairdconnectivity: Add platform GPIO and read..

### DIFF
--- a/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/CMakeLists.txt
@@ -28,6 +28,7 @@ target_include_directories(platform_s
     PUBLIC
         .
         ../common/bl5340/partition
+        services/include
 )
 
 target_include_directories(platform_ns
@@ -42,4 +43,9 @@ if(BL2)
         PRIVATE
             .
     )
+endif()
+
+if (TFM_PARTITION_PLATFORM)
+install(FILES       services/include/tfm_ioctl_api.h
+        DESTINATION ${TFM_INSTALL_PATH}/interface/include)
 endif()

--- a/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_ioctl_api.h
+++ b/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_ioctl_api.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+/** @file
+ * @brief TFM IOCTL API header.
+ */
+
+
+#ifndef TFM_IOCTL_API_H__
+#define TFM_IOCTL_API_H__
+
+/**
+ * @defgroup tfm_ioctl_api TFM IOCTL API
+ * @{
+ *
+ */
+
+#include <limits.h>
+#include <stdint.h>
+#include <tfm_api.h>
+#include <tfm_platform_api.h>
+
+/* Include core IOCTL services */
+#include <tfm_ioctl_core_api.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Board specific IOCTL services can be added here */
+
+#ifdef __cplusplus
+}
+#endif
+
+/**
+ * @}
+ */
+
+#endif /* TFM_IOCTL_API_H__ */

--- a/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_read_ranges.h
+++ b/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_read_ranges.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
+ */
+
+#ifndef TFM_READ_RANGES_H__
+#define TFM_READ_RANGES_H__
+
+#include <tfm_ioctl_core_api.h>
+
+#include "nrf.h"
+
+#define FICR_BASE               NRF_FICR_S_BASE
+
+#define FICR_INFO_ADDR          (FICR_BASE + offsetof(NRF_FICR_Type, INFO))
+#define FICR_INFO_SIZE          (sizeof(FICR_INFO_Type))
+
+#define FICR_NFC_ADDR           (FICR_BASE + offsetof(NRF_FICR_Type, NFC))
+#define FICR_NFC_SIZE           (sizeof(FICR_NFC_Type))
+
+#define FICR_XOSC32MTRIM_ADDR   (FICR_BASE + offsetof(NRF_FICR_Type, XOSC32MTRIM))
+#define FICR_XOSC32MTRIM_SIZE   (sizeof(uint32_t))
+
+/* Used by nrf_erratas.h */
+#define FICR_RESTRICTED_ADDR    (FICR_BASE + 0x130)
+#define FICR_RESTRICTED_SIZE    0x8
+
+static const struct tfm_read_service_range ranges[] = {
+	{ .start = FICR_INFO_ADDR, .size = FICR_INFO_SIZE },
+	{ .start = FICR_NFC_ADDR, .size = FICR_NFC_SIZE },
+	{ .start = FICR_RESTRICTED_ADDR, .size = FICR_RESTRICTED_SIZE },
+	{ .start = FICR_XOSC32MTRIM_ADDR, .size = FICR_XOSC32MTRIM_SIZE },
+};
+
+#endif /* TFM_READ_RANGES_H__ */

--- a/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/src/tfm_platform_system.c
+++ b/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/src/tfm_platform_system.c
@@ -7,6 +7,8 @@
 
 #include "platform/include/tfm_platform_system.h"
 #include "cmsis.h"
+#include "tfm_platform_hal_ioctl.h"
+#include "tfm_ioctl_core_api.h"
 
 void tfm_platform_hal_system_reset(void)
 {
@@ -18,10 +20,16 @@ enum tfm_platform_err_t tfm_platform_hal_ioctl(tfm_platform_ioctl_req_t request,
                                                psa_invec  *in_vec,
                                                psa_outvec *out_vec)
 {
-    (void)request;
-    (void)in_vec;
-    (void)out_vec;
+	/* Core IOCTL services */
+	switch (request) {
+	case TFM_PLATFORM_IOCTL_READ_SERVICE:
+		return tfm_platform_hal_read_service(in_vec, out_vec);
+	case TFM_PLATFORM_IOCTL_GPIO_SERVICE:
+		return tfm_platform_hal_gpio_service(in_vec, out_vec);
+	/* Board specific IOCTL services */
 
-    /* Not needed for this platform */
-    return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+	/* Not a supported IOCTL service.*/
+	default:
+		return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+	}
 }

--- a/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
@@ -50,6 +50,7 @@ target_include_directories(platform_s
         ${HAL_NORDIC_PATH}/nrfx/mdk
         ${HAL_NORDIC_PATH}/nrfx/drivers/include
         ${NRF_FOLDER_PATH}/common
+        ${NRF_FOLDER_PATH}/services/include
         ${PLATFORM_DIR}/..
 )
 
@@ -71,6 +72,19 @@ target_sources(platform_s
     PUBLIC
         plat_test.c
 )
+
+if(TFM_PARTITION_PLATFORM)
+    target_sources(platform_s
+        PRIVATE
+            ${NRF_FOLDER_PATH}/services/src/tfm_platform_hal_ioctl.c
+            ${NRF_FOLDER_PATH}/services/src/tfm_ioctl_core_s_api.c
+    )
+
+    target_sources(platform_ns
+        PRIVATE
+            ${NRF_FOLDER_PATH}/services/src/tfm_ioctl_core_ns_api.c
+    )
+endif()
 
 if(SECURE_UART1)
     target_sources(platform_s
@@ -100,6 +114,7 @@ target_include_directories(platform_ns
         ${HAL_NORDIC_PATH}/nrfx/drivers/include
         ${NRF_FOLDER_PATH}/common
         ${PLATFORM_DIR}/..
+        ${NRF_FOLDER_PATH}/services/include
     PRIVATE
         ${PLATFORM_DIR}/../interface/include
 )
@@ -141,4 +156,10 @@ if(BL2)
             ${HAL_NORDIC_PATH}/nrfx/drivers/src/nrfx_qspi.c
             ${NRF_FOLDER_PATH}/nrfx_glue.c
     )
+endif()
+
+if (TFM_PARTITION_PLATFORM)
+install(FILES       ${NRF_FOLDER_PATH}/services/include/tfm_ioctl_core_api.h
+        DESTINATION ${TFM_INSTALL_PATH}/interface/include)
+
 endif()


### PR DESCRIPTION
..service

Add lairdconnectivity platform services for GPIO and read as core
platform services.
The services are added in a way that makes it possible for out-of-tree
boards to include these core services while still being able to add
their own.

Change-Id: If3163c4810f6578ccf76e80f5a8f3b97a95dc591
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit f1cf48f8f96308c04ed41b208ee68e6d2855099b)

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit 5d32c3e64b3d589548e881eeeeb37d84944c90af)