### PR TITLE
[nrf fromlist] platform: Don't  configure FPU for nrf9160

### DIFF
--- a/platform/ext/target/lairdconnectivity/common/bl5340/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/common/bl5340/CMakeLists.txt
@@ -92,6 +92,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF5340_XXAA_APPLICATION
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
@@ -88,6 +88,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF5340_XXAA_APPLICATION
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(platform_s
 target_compile_definitions(platform_s
     PUBLIC
         NRF9160_XXAA
+        NRF_SKIP_FICR_NS_COPY_TO_RAM
 )
 
 #========================= Platform Non-Secure ================================#
@@ -87,6 +88,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF9160_XXAA
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
@@ -562,7 +562,7 @@ enum tfm_plat_err_t spu_init_cfg(void)
 enum tfm_plat_err_t spu_periph_init_cfg(void)
 {
     /* Peripheral configuration */
-    spu_peripheral_config_non_secure((uint32_t)NRF_FPU, false);
+
     /* The following peripherals share ID:
      * - REGULATORS
      * - OSCILLATORS


### PR DESCRIPTION
-As described in the Product Specification the FPU is not
affected by any security configuration and the the
Present field in the PERM SPU register is not enabled.
-Add missing NRF_SKIP_FICR_NS_COPY_TO_RAM to BL2 build and nrf9160
platform.

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/13999
Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/13994

Change-Id: I76517363d548c9a5f4b3461aee2fdce801996842
Change-Id: Ib99dbc36b45bc4659cb8eebc8b9143b10fe32da4

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>