### PR TITLE
[nrf fromtree] platform: nordic_nrf: Add missing ...

### DIFF
--- a/platform/ext/target/lairdconnectivity/common/bl5340/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/common/bl5340/CMakeLists.txt
@@ -92,6 +92,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF5340_XXAA_APPLICATION
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
@@ -88,6 +88,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF5340_XXAA_APPLICATION
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(platform_s
 target_compile_definitions(platform_s
     PUBLIC
         NRF9160_XXAA
+        NRF_SKIP_FICR_NS_COPY_TO_RAM
 )
 
 #========================= Platform Non-Secure ================================#
@@ -87,6 +88,7 @@ if(BL2)
     target_compile_definitions(platform_bl2
         PUBLIC
             NRF9160_XXAA
+            NRF_SKIP_FICR_NS_COPY_TO_RAM
     )
 endif()
 


### PR DESCRIPTION
Add missing NRF_SKIP_FICR_NS_COPY_TO_RAM to BL2 build and nrf9160
platform.

Change-Id: Ib99dbc36b45bc4659cb8eebc8b9143b10fe32da4
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit 9421f6dbd50101feb498038eab02abdf3e01237c)
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>