### PR TITLE
Revert "[nrf fromlist] secure_fw: partitions: Make ITS a weak depende…

### DIFF
--- a/secure_fw/partitions/crypto/tfm_crypto.yaml
+++ b/secure_fw/partitions/crypto/tfm_crypto.yaml
@@ -481,7 +481,7 @@
       "version_policy": "STRICT"
     },
   ],
-  "weak_dependencies": [
+  "dependencies": [
     "TFM_INTERNAL_TRUSTED_STORAGE_SERVICE"
   ]
 }


### PR DESCRIPTION
…ncy for crypto"

This reverts commit 6cd4acfb247cc86c8d90c260d52b372a43c26cdd.
Upstream PR was not approved in its current form.
Abandoned in favour of an out-of-tree workaround instead.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>