### PR TITLE
TF-M: Reset nRF peripherals during boot

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -86,6 +86,7 @@ if (NRF_HW_INIT_RESET_ON_BOOT)
     target_compile_definitions(platform_s
         PUBLIC
             NRF_HW_INIT_RESET_ON_BOOT
+            $<$<BOOL:${NRF_HW_INIT_NRF_PERIPHERALS}>:NRF_HW_INIT_NRF_PERIPHERALS>
     )
 endif()
 

--- a/platform/ext/target/nordic_nrf/common/core/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/core/config.cmake
@@ -22,3 +22,8 @@ set(PLATFORM_SLIH_IRQ_TEST_SUPPORT      ON          CACHE BOOL    "Platform supp
 set(PLATFORM_FLIH_IRQ_TEST_SUPPORT      ON          CACHE BOOL    "Platform supports FLIH IRQ tests")
 
 set(NRF_HW_INIT_RESET_ON_BOOT OFF CACHE BOOL "Initialize internal architecture state at boot")
+set(NRF_HW_INIT_NRF_PERIPHERALS OFF CACHE BOOL "Initialize nRF peripherals at boot")
+
+if (NRF_HW_INIT_NRF_PERIPHERALS AND NOT NRF_HW_INIT_RESET_ON_BOOT)
+        message(FATAL_ERROR "NRF_HW_INIT_PERIPHERALS_ON_BOOT depends on NRF_HW_INIT_RESET_ON_BOOT")
+endif()

--- a/platform/ext/target/nordic_nrf/common/core/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/core/config.cmake
@@ -21,4 +21,4 @@ set(NULL_POINTER_EXCEPTION_DETECTION    FALSE       CACHE BOOL
 set(PLATFORM_SLIH_IRQ_TEST_SUPPORT      ON          CACHE BOOL    "Platform supports SLIH IRQ tests")
 set(PLATFORM_FLIH_IRQ_TEST_SUPPORT      ON          CACHE BOOL    "Platform supports FLIH IRQ tests")
 
-set(NRF_HW_INIT_RESET_ON_BOOT CACHE BOOL OFF "Initialize internal architecture state at boot")
+set(NRF_HW_INIT_RESET_ON_BOOT OFF CACHE BOOL "Initialize internal architecture state at boot")

--- a/platform/ext/target/nordic_nrf/common/core/hw_init.c
+++ b/platform/ext/target/nordic_nrf/common/core/hw_init.c
@@ -8,6 +8,13 @@
 #include <nrf.h>
 #include "array.h"
 
+#include <string.h>
+
+#include <hal/nrf_rtc.h>
+#include <hal/nrf_uarte.h>
+#include <hal/nrf_clock.h>
+#include <hal/nrf_dppi.h>
+
 /* This routine clears all ARM MPU region configuration. */
 static void hw_init_mpu(void)
 {
@@ -18,6 +25,78 @@ static void hw_init_mpu(void)
 		ARM_MPU_ClrRegion(i);
 	}
 }
+
+#if defined(NRF_HW_INIT_NRF_PERIPHERALS)
+#if defined(NRF_RTC0) || defined(NRF_RTC1) || defined(NRF_RTC2)
+static inline void nrf_cleanup_rtc(NRF_RTC_Type * rtc_reg)
+{
+    nrf_rtc_task_trigger(rtc_reg, NRF_RTC_TASK_STOP);
+    nrf_rtc_event_disable(rtc_reg, 0xFFFFFFFF);
+    nrf_rtc_int_disable(rtc_reg, 0xFFFFFFFF);
+}
+#endif
+
+static void nrf_cleanup_uarte(NRF_UARTE_Type * uarte_reg)
+{
+/* All subscribe + reserved, i.e from SUBSCRIBE_STARTRX to EVENTS_CTS */
+#define NRF_UARTE_SUBSCRIBE_CONF_OFFS offsetof(NRF_UARTE_Type, SUBSCRIBE_STARTRX)
+#define NRF_UARTE_SUBSCRIBE_CONF_SIZE (offsetof(NRF_UARTE_Type, EVENTS_CTS) -\
+                                       NRF_UARTE_SUBSCRIBE_CONF_OFFS)
+
+/* All publish + reserved, i.e from PUBLISH_CTS to SHORTS */
+#define NRF_UARTE_PUBLISH_CONF_OFFS offsetof(NRF_UARTE_Type, PUBLISH_CTS)
+#define NRF_UARTE_PUBLISH_CONF_SIZE (offsetof(NRF_UARTE_Type, SHORTS) -\
+                                     NRF_UARTE_PUBLISH_CONF_OFFS)
+
+    nrf_uarte_disable(uarte_reg);
+    nrf_uarte_int_disable(uarte_reg, 0xFFFFFFFF);
+#if defined(NRF_DPPIC)
+    /* Clear all SUBSCRIBE configurations. */
+    memset((uint8_t *)uarte_reg + NRF_UARTE_SUBSCRIBE_CONF_OFFS, 0, NRF_UARTE_SUBSCRIBE_CONF_SIZE);
+    /* Clear all PUBLISH configurations. */
+    memset((uint8_t *)uarte_reg + NRF_UARTE_PUBLISH_CONF_OFFS, 0, NRF_UARTE_PUBLISH_CONF_SIZE);
+#endif
+}
+
+static void nrf_cleanup_peripheral_interconnect(void)
+{
+#if defined(NRF_PPI)
+    nrf_ppi_channels_disable_all(NRF_PPI);
+#endif
+#if defined(NRF_DPPIC)
+    nrf_dppi_channels_disable_all(NRF_DPPIC);
+#endif
+}
+
+static void nrf_cleanup_clock(void)
+{
+    nrf_clock_int_disable(NRF_CLOCK, 0xFFFFFFFF);
+}
+
+static void hw_init_nrf_peripherals(void)
+{
+#if defined(NRF_RTC0)
+    nrf_cleanup_rtc(NRF_RTC0);
+#endif
+#if defined(NRF_RTC1)
+    nrf_cleanup_rtc(NRF_RTC1);
+#endif
+#if defined(NRF_RTC2)
+    nrf_cleanup_rtc(NRF_RTC2);
+#endif
+
+#if defined(NRF_UARTE0)
+    nrf_cleanup_uarte(NRF_UARTE0);
+#endif
+#if defined(NRF_UARTE1)
+    nrf_cleanup_uarte(NRF_UARTE1);
+#endif
+
+    nrf_cleanup_peripheral_interconnect();
+
+    nrf_cleanup_clock();
+}
+#endif /* NRF_HW_INIT_NRF_PERIPHERALS */
 
 /* This routine resets Cortex-M system control block components and core
  * registers.
@@ -45,6 +124,9 @@ void hw_init_reset_on_boot(void)
 		NVIC->ICPR[i] = 0xFFFFFFFF;
 	}
 
+#if defined(NRF_HW_INIT_NRF_PERIPHERALS)
+	hw_init_nrf_peripherals();
+#endif
 	/* Restore Interrupts */
 	__enable_irq();
 


### PR DESCRIPTION
Reset nRF peripherals during boot.
This is required when using an MCUBoot version without CONFIG_MCUBOOT_NRF_CLEANUP_PERIPHERAL enabled.
This is by default enabled starting from NCS 1.4.