### PR TITLE
[nrf fromtree] Bug fixes for isolation level 2

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/gcc/nordic_nrf_s.ld
+++ b/platform/ext/target/nordic_nrf/common/core/gcc/nordic_nrf_s.ld
@@ -201,6 +201,10 @@ SECTIONS
         *psa_lifecycle.*(.rodata*)
         *tfm_log_raw.*(.text*)             /* NXP */
         *tfm_log_raw.*(.rodata*)
+        *tfm_psa_call_pack.*(.text*)
+        *tfm_psa_call_pack.*(.rodata*)
+        *psa_interface_svc.*(.text*)
+        *psa_interface_svc.*(.rodata*)
         . = ALIGN(32);
     } > FLASH
     Image$$TFM_UNPRIV_CODE$$RO$$Base = ADDR(.TFM_UNPRIV_CODE);

--- a/platform/ext/target/nordic_nrf/common/nrf5340/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/config.cmake
@@ -10,7 +10,6 @@ include(${PLATFORM_PATH}/common/core/config.cmake)
 
 set(SECURE_UART1                        ON         CACHE BOOL      "Enable secure UART1")
 set(PSA_API_TEST_TARGET                 "nrf5340"  CACHE STRING    "PSA API test target")
-set(ITS_NUM_ASSETS                      "5"        CACHE STRING    "The maximum number of assets to be stored in the Internal Trusted Storage area")
 set(NRF_NS_STORAGE                      OFF        CACHE BOOL      "Enable non-secure storage partition")
 set(NRF_NS_SECONDARY                    ${BL2}     CACHE BOOL      "Enable non-secure secondary partition")
 set(TFM_ITS_ENC_NONCE_LENGTH            "12"       CACHE STRING    "The size of the nonce used in ITS encryption in bytes")

--- a/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
@@ -10,7 +10,6 @@ include(${PLATFORM_PATH}/common/core/config.cmake)
 
 set(SECURE_UART1                        ON         CACHE BOOL      "Enable secure UART1")
 set(PSA_API_TEST_TARGET                 "nrf9160"  CACHE STRING    "PSA API test target")
-set(ITS_NUM_ASSETS                      "5"        CACHE STRING    "The maximum number of assets to be stored in the Internal Trusted Storage area")
 set(NRF_NS_STORAGE                      OFF        CACHE BOOL      "Enable non-secure storage partition")
 set(NRF_NS_SECONDARY                    ${BL2}     CACHE BOOL      "Enable non-secure secondary partition")
 set(TFM_ITS_ENC_NONCE_LENGTH            "12"       CACHE STRING    "The size of the nonce used in ITS encryption in bytes")

--- a/secure_fw/partitions/crypto/crypto_aead.c
+++ b/secure_fw/partitions/crypto/crypto_aead.c
@@ -30,7 +30,7 @@ psa_status_t tfm_crypto_aead_encrypt(psa_invec in_vec[],
 #else
     psa_status_t status = PSA_SUCCESS;
 
-    CRYPTO_IN_OUT_LEN_VALIDATE(in_len, 1, 3, out_len, 1, 1);
+    CRYPTO_IN_OUT_LEN_VALIDATE(in_len, 1, 3, out_len, 0, 1);
 
     if ((in_vec[0].len != sizeof(struct tfm_crypto_pack_iovec))) {
         return PSA_ERROR_PROGRAMMER_ERROR;


### PR DESCRIPTION
Add the psa_call_pack and psa_interface_svc to
the unprivilleged part of the image. When
isolation level >1 is used the PSA application
RoT partitions (such as PS) run in unprivilleged
mode and they need to be able to access these
functions when accessing any other RoT services
(such as ITS).

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/15740

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>
Change-Id: Id82e8fadd1822930162b7bb8b1f434891c5f20d2