### PR TITLE
[nrf fromtree] tfm: Export IOCTL non-secure API source file to install

### DIFF
--- a/interface/src/tfm_crypto_ipc_api.c
+++ b/interface/src/tfm_crypto_ipc_api.c
@@ -1413,7 +1413,7 @@ psa_status_t psa_key_derivation_get_capacity(
     };
 
     psa_outvec out_vec[] = {
-        {.base = &(operation->handle), .len = sizeof(uint32_t)},
+        {.base = (uint32_t *) &(operation->handle), .len = sizeof(uint32_t)},
         {.base = capacity, .len = sizeof(size_t)},
     };
 

--- a/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
+++ b/platform/ext/target/lairdconnectivity/common/core/CMakeLists.txt
@@ -161,4 +161,7 @@ if (TFM_PARTITION_PLATFORM)
 install(FILES       ${NRF_FOLDER_PATH}/services/include/tfm_ioctl_core_api.h
         DESTINATION ${TFM_INSTALL_PATH}/interface/include)
 
+install(FILES       ${NRF_FOLDER_PATH}/services/src/tfm_ioctl_core_ns_api.c
+        DESTINATION ${TFM_INSTALL_PATH}/interface/src)
+
 endif()

--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -178,4 +178,7 @@ if (TFM_PARTITION_PLATFORM)
 install(FILES       services/include/tfm_ioctl_core_api.h
         DESTINATION ${TFM_INSTALL_PATH}/interface/include)
 
+install(FILES       services/src/tfm_ioctl_core_ns_api.c
+        DESTINATION ${TFM_INSTALL_PATH}/interface/src)
+
 endif()


### PR DESCRIPTION
Add the non-secure API IOCTL functions for the nordic platform to the
set of source files exported in the install folder.
In the case where this is built by an external build system instead of
the platform_ns library then this source file needs to be included in
the non-secure application and its build system.
