### PR TITLE
[nrf noup] Add configurable stack size for crypto partition.

### DIFF
--- a/secure_fw/partitions/crypto/tfm_crypto.yaml
+++ b/secure_fw/partitions/crypto/tfm_crypto.yaml
@@ -12,7 +12,7 @@
   "priority": "NORMAL",
   "model": "SFN",
   "entry_init": "tfm_crypto_init",
-  "stack_size": "0x2000",
+  "stack_size": "CRYPTO_STACK_SIZE",
   "secure_functions": [
     {
       "name": "TFM_CRYPTO_GET_KEY_ATTRIBUTES",

--- a/tools/templates/partition_intermedia.template
+++ b/tools/templates/partition_intermedia.template
@@ -8,6 +8,7 @@
 /***********{{utilities.donotedit_warning}}***********/
 
 #include <stdint.h>
+#include "region_defs.h"
 
 {% if config_impl['CONFIG_TFM_SPM_BACKEND_IPC'] == '1' or manifest.model == "IPC" %}
 uint8_t {{manifest.name.lower()}}_stack[{{manifest.stack_size}}] __attribute__((aligned(8)));


### PR DESCRIPTION
Add configurable stack size for the TF-M crypto partition.
This is a temporary method of adding this configuration since the
upstream TF-M implementation for this feature could not be backported
in a clean way.

Should be replaced by the upstream feature in future TF-M upmerge:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/16125

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>