### PR TITLE
[nrf toup] platform: nordic_nrf: Replace deprecated API with new one

### DIFF
--- a/platform/ext/target/lairdconnectivity/common/bl5340/target_cfg.c
+++ b/platform/ext/target/lairdconnectivity/common/bl5340/target_cfg.c
@@ -750,8 +750,8 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
      * This configuration can be done only from secure code, as otherwise those
      * register fields are not accessible.  That's why it is placed here.
      */
-    nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-    nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+    nrf_gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
+    nrf_gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
 
     /* Enable the instruction and data cache (this can be done only from secure
      * code; that's why it is placed here).

--- a/platform/ext/target/lairdconnectivity/common/core/plat_test.c
+++ b/platform/ext/target/lairdconnectivity/common/core/plat_test.c
@@ -47,7 +47,7 @@ static void timer_init(NRF_TIMER_Type * TIMER, uint32_t ticks)
 {
     nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
     nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-    nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_1MHz);
+    nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
     nrf_timer_cc_set(TIMER, NRF_TIMER_CC_CHANNEL0, ticks);
     /* Clear the timer once event is generated. */
     nrf_timer_shorts_enable(TIMER, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);

--- a/platform/ext/target/nordic_nrf/common/core/plat_test.c
+++ b/platform/ext/target/nordic_nrf/common/core/plat_test.c
@@ -37,7 +37,7 @@ static void timer_init(NRF_TIMER_Type * TIMER, uint32_t ticks)
 {
     nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
     nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-    nrf_timer_frequency_set(TIMER, NRF_TIMER_FREQ_1MHz);
+    nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
     nrf_timer_cc_set(TIMER, NRF_TIMER_CC_CHANNEL0, ticks);
     /* Clear the timer once event is generated. */
     nrf_timer_shorts_enable(TIMER, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -101,7 +101,7 @@ struct tfm_read_service_range {
  * @brief Perform a GPIO MCU select operation.
  *
  * @param pin_number         Pin_number.
- * @param mcu                MCU to control the pin, use nrf_gpio_pin_mcusel_t values.
+ * @param mcu                MCU to control the pin, use nrf_gpio_pin_sel_t values.
 
  * @param[out] result        Result of operation
  *

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -66,14 +66,14 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 	return err;
 }
 
-#if defined(GPIO_PIN_CNF_MCUSEL_Msk)
+#if NRF_GPIO_HAS_SEL
 static bool valid_mcu_select(uint32_t mcu)
 {
 	switch (mcu) {
-	case NRF_GPIO_PIN_MCUSEL_APP:
-	case NRF_GPIO_PIN_MCUSEL_NETWORK:
-	case NRF_GPIO_PIN_MCUSEL_PERIPHERAL:
-	case NRF_GPIO_PIN_MCUSEL_TND:
+	case NRF_GPIO_PIN_SEL_APP:
+	case NRF_GPIO_PIN_SEL_NETWORK:
+	case NRF_GPIO_PIN_SEL_PERIPHERAL:
+	case NRF_GPIO_PIN_SEL_TND:
 		return true;
 	default:
 		return false;
@@ -84,7 +84,7 @@ static uint32_t gpio_service_mcu_select(struct tfm_gpio_service_args * args)
 {
 	if (nrf_gpio_pin_present_check(args->mcu_select.pin_number) &&
 	    valid_mcu_select(args->mcu_select.mcu)) {
-		nrf_gpio_pin_mcu_select(args->mcu_select.pin_number, args->mcu_select.mcu);
+		nrf_gpio_pin_control_select(args->mcu_select.pin_number, args->mcu_select.mcu);
 		return 0;
 	} else {
 		return -1;
@@ -118,5 +118,5 @@ tfm_platform_hal_gpio_service(const psa_invec  *in_vec, const psa_outvec *out_ve
 
 	return TFM_PLATFORM_ERR_SUCCESS;
 }
-#endif /* defined(GPIO_PIN_CNF_MCUSEL_Msk) */
+#endif /* NRF_GPIO_HAS_SEL */
 

--- a/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
@@ -777,8 +777,8 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
      * This configuration can be done only from secure code, as otherwise those
      * register fields are not accessible.  That's why it is placed here.
      */
-    nrf_gpio_pin_mcu_select(PIN_XL1, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
-    nrf_gpio_pin_mcu_select(PIN_XL2, NRF_GPIO_PIN_MCUSEL_PERIPHERAL);
+    nrf_gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
+    nrf_gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
 
     /* Enable the instruction and data cache (this can be done only from secure
      * code; that's why it is placed here).


### PR DESCRIPTION
This commit replaces API that became deprecated with the release
of nrfx2.9 - see CHANGELOG in NordicSemiconductor:nrfx repository
https://github.com/NordicSemiconductor/nrfx/blob/v2.9.0/CHANGELOG.md

Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>