### PR TITLE
[nrf toup] platform: nordic_nrf: Fixed NRF_NS_SECONDARY bug

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
@@ -100,4 +100,5 @@ endif()
 target_compile_definitions(platform_region_defs
     INTERFACE
         $<$<BOOL:${NRF_NS_STORAGE}>:NRF_NS_STORAGE>
+        $<$<BOOL:${NRF_NS_SECONDARY}>:NRF_NS_SECONDARY>
 )


### PR DESCRIPTION
Fixed CMakeLists.txt bug where we added NRF_NS_SECONDARY to nrf53, but
forgot to add it to nrf91. This broke NRF_NS_SECONDARY for 91.

Fix from Joan Minana.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>