### PR TITLE
[nrf noup] Added workaround for missing Debug symbols in tfm_s image

### DIFF
--- a/secure_fw/CMakeLists.txt
+++ b/secure_fw/CMakeLists.txt
@@ -47,10 +47,28 @@ target_compile_options(tfm_s
         ${COMPILER_CP_FLAG}
 )
 
+# This is a workaround to add debug symbols for the veneer functions of the
+# secure part of TF-M. The problem is that the linker strips away the debug
+# section of the functions called by a veneer function. The root cause is not
+# fully clear, but might be a bug in the linker as it removes the debug
+# sections with the reason of being unused but keeps the actual .text section
+# of the functions. To work around this we instruct the linker to expilicitly
+# keep the, "unused" functions.
+if(EXISTS ${CMAKE_BINARY_DIR}/generated/tools/tfm_veneers_functions.txt)
+    file(STRINGS ${CMAKE_BINARY_DIR}/generated/tools/tfm_veneers_functions.txt veneer_functions)
+else()
+    set(veneer_functions "")
+endif()
+
+foreach(function ${veneer_functions})
+    list(APPEND veneer_link_options -Wl,--undefined=${function})
+endforeach()
+
 target_link_options(tfm_s
     PRIVATE
         --entry=Reset_Handler
-        $<$<C_COMPILER_ID:GNU>:-Wl,-Map=${CMAKE_BINARY_DIR}/bin/tfm_s.map>
+        $<$<C_COMPILER_ID:GNU>:-Wl,-Map=${CMAKE_BINARY_DIR}/bin/tfm_s.map> 
+        $<$<C_COMPILER_ID:GNU>:${veneer_link_options}>
         $<$<C_COMPILER_ID:ARMClang>:--map>
         $<$<C_COMPILER_ID:IAR>:--map\;${CMAKE_BINARY_DIR}/bin/tfm_s.map>
     PUBLIC

--- a/tools/templates/veneer_function_names.template
+++ b/tools/templates/veneer_function_names.template
@@ -1,0 +1,5 @@
+{% for partition in partitions %}
+{% for function in partition.manifest.secure_functions%}
+{{function.signal.lower()}}
+{% endfor %}
+{% endfor %}

--- a/tools/tfm_generated_file_list.yaml
+++ b/tools/tfm_generated_file_list.yaml
@@ -34,6 +34,12 @@
         "output": "interface/include/tfm_veneers.h"
     },
     {
+        "name": "Secure Veneers functions file",
+        "short_name": "tfm_veneers_functions",
+        "template": "tools/templates/veneer_function_names.template",
+        "output": "tools/tfm_veneers_functions.txt"
+    },
+    {
         "name": "Secure IRQ handlers",
         "short_name": "tfm_secure_irq_handlers",
         "template": "secure_fw/spm/cmsis_func/tfm_secure_irq_handlers.inc.template",


### PR DESCRIPTION
patches submitted to upstream for review, and revisions to them:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/16703

The linker removes the debug section of the object files, that are
invoked indirectly via the generated veneer functions. Why this
happens, is not fully clear. This commit adds a workaround that
tells the linker to include the functions that are called via a
veneer function. This is done by generating the linker option
-Wl,--undefined=function_name for all veneer functions and writing
them into a file that then later gets added as linker option to
the tfm_s target.

As mentioned it is a workaround, as the root cause is not fully
clear and might be a bug in the ld linker.

Signed-off-by: Markus Swarowsky <markus.swarowsky@nordicsemi.no>