### PR TITLE
[nrf toup] nrf: Replace deprecated enum for timer prescaler

### DIFF
--- a/platform/ext/target/lairdconnectivity/common/core/plat_test.c
+++ b/platform/ext/target/lairdconnectivity/common/core/plat_test.c
@@ -39,6 +39,7 @@
 #endif
 
 #define TIMER_RELOAD_VALUE          (1*1000*1000)
+#define TIMER_FREQ_HZ               (1000000)
 
 /* Area used by psa-arch-tests to keep state. */
 #define PSA_TEST_SCRATCH_AREA_SIZE  (0x400)
@@ -47,7 +48,10 @@ static void timer_init(NRF_TIMER_Type * TIMER, uint32_t ticks)
 {
     nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
     nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-    nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
+    nrf_timer_prescaler_set(TIMER,
+                            NRF_TIMER_PRESCALER_CALCULATE(
+                                NRF_TIMER_BASE_FREQUENCY_GET(TIMER),
+                                TIMER_FREQ_HZ));
     nrf_timer_cc_set(TIMER, NRF_TIMER_CC_CHANNEL0, ticks);
     /* Clear the timer once event is generated. */
     nrf_timer_shorts_enable(TIMER, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);

--- a/platform/ext/target/nordic_nrf/common/core/plat_test.c
+++ b/platform/ext/target/nordic_nrf/common/core/plat_test.c
@@ -32,12 +32,16 @@
 #endif
 
 #define TIMER_RELOAD_VALUE (1*1000*1000)
+#define TIMER_FREQ_HZ      (1000000)
 
 static void timer_init(NRF_TIMER_Type * TIMER, uint32_t ticks)
 {
     nrf_timer_mode_set(TIMER, NRF_TIMER_MODE_TIMER);
     nrf_timer_bit_width_set(TIMER, NRF_TIMER_BIT_WIDTH_32);
-    nrf_timer_prescaler_set(TIMER, NRF_TIMER_FREQ_1MHz);
+    nrf_timer_prescaler_set(TIMER,
+                            NRF_TIMER_PRESCALER_CALCULATE(
+                                NRF_TIMER_BASE_FREQUENCY_GET(TIMER),
+                                TIMER_FREQ_HZ));
     nrf_timer_cc_set(TIMER, NRF_TIMER_CC_CHANNEL0, ticks);
     /* Clear the timer once event is generated. */
     nrf_timer_shorts_enable(TIMER, NRF_TIMER_SHORT_COMPARE0_CLEAR_MASK);


### PR DESCRIPTION
This commit replaces deprecated nrf_timer_frequency_t enum with new numerical value.

Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>