### PR TITLE
[nrf noup] secure_fw: Fix stack seal writing using invalid pointer

### DIFF
--- a/secure_fw/spm/cmsis_func/spm_func.c
+++ b/secure_fw/spm/cmsis_func/spm_func.c
@@ -50,9 +50,16 @@ struct iovec_params_t {
 #error Multi core is not supported by Function mode
 #endif
 
-REGION_DECLARE_T(Image$$, TFM_SECURE_STACK, $$ZI$$Base, uint32_t);
-REGION_DECLARE_T(Image$$, TFM_SECURE_STACK, $$ZI$$Limit, struct iovec_args_t *);
-REGION_DECLARE_T(Image$$, ER_INITIAL_PSP_SEAL, $$ZI$$Base, uint32_t *);
+REGION_DECLARE(Image$$, TFM_SECURE_STACK, $$ZI$$Base);
+REGION_DECLARE(Image$$, TFM_SECURE_STACK, $$ZI$$Limit);
+REGION_DECLARE_T(Image$$, ER_INITIAL_PSP_SEAL, $$ZI$$Base, uint32_t)[2];
+
+static inline uint32_t *tfm_secure_stack_iovec_get(void)
+{
+    uint32_t secure_stack_limit = (uint32_t)&REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Limit);
+
+    return (uint32_t *)(secure_stack_limit - sizeof(struct iovec_args_t));
+}
 
 /*
  * Function to seal the psp stacks for Function model of TF-M.
@@ -76,7 +83,8 @@ void tfm_spm_seal_psp_stacks(void)
      *                                      |                         |
      * Image$$TFM_SECURE_STACK$$ZI$$Base->  +-------------------------+
      */
-    uint32_t *tfm_secure_stack_seal = ((uint32_t *)&REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Limit)[-1]) - 2;
+    uint32_t *tfm_secure_stack_seal = tfm_secure_stack_iovec_get() - 2;
+
     *(tfm_secure_stack_seal) = TFM_STACK_SEAL_VALUE;
     *(tfm_secure_stack_seal + 1) = TFM_STACK_SEAL_VALUE;
 
@@ -84,11 +92,11 @@ void tfm_spm_seal_psp_stacks(void)
      * Seal the ER_INITIAL_PSP by writing the seal value to the reserved
      * region.
      */
-    uint32_t *arm_lib_stck_seal_base =
-        ((uint32_t *)&REGION_NAME(Image$$, ER_INITIAL_PSP_SEAL, $$ZI$$Base)[-1]) - 2;
+    uint32_t *arm_lib_stack_seal_base =
+        (uint32_t *)&REGION_NAME(Image$$, ER_INITIAL_PSP_SEAL, $$ZI$$Base);
 
-    *(arm_lib_stck_seal_base) = TFM_STACK_SEAL_VALUE;
-    *(arm_lib_stck_seal_base + 1) = TFM_STACK_SEAL_VALUE;
+    *(arm_lib_stack_seal_base) = TFM_STACK_SEAL_VALUE;
+    *(arm_lib_stack_seal_base + 1) = TFM_STACK_SEAL_VALUE;
 }
 
 /*
@@ -385,8 +393,10 @@ static enum tfm_status_e check_irq_partition_state(
  */
 static struct iovec_args_t *get_iovec_args_stack_address(uint32_t partition_idx)
 {
+    (void)partition_idx;
+
     /* Save the iovecs on the common stack. */
-    return &REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Limit)[-1];
+    return (struct iovec_args_t *)tfm_secure_stack_iovec_get();
 }
 
 /**
@@ -505,7 +515,8 @@ static enum tfm_status_e tfm_start_partition(
      * So the memory area, that can actually be used as stack by the partitions
      * starts at a lower address.
      */
-    uint32_t *tfm_secure_stack_seal = ((uint32_t *)&REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Limit)[-1]) - 2;
+    uint32_t *tfm_secure_stack_seal = tfm_secure_stack_iovec_get() - 2;
+
     partition_psp = (uint32_t) tfm_secure_stack_seal;
     partition_psplim =
         (uint32_t)&REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Base);
@@ -655,7 +666,7 @@ static enum tfm_status_e tfm_return_from_partition(uint32_t *excReturn)
             (uint32_t)REGION_NAME(Image$$, ER_INITIAL_PSP, $$ZI$$Base);
         tfm_arch_set_psplim(psp_stack_bottom);
 
-        iovec_args = &REGION_NAME(Image$$, TFM_SECURE_STACK, $$ZI$$Limit)[-1];
+        iovec_args = get_iovec_args_stack_address(return_partition_idx);
 
         for (i = 0; i < curr_part_data->iovec_args.out_len; ++i) {
             curr_part_data->orig_outvec[i].len = iovec_args->out_vec[i].len;


### PR DESCRIPTION
fixup! [nrf noup] Fix build warnings

Fix the stack seal writing of the stack seal value to an invalid pointer. This caused a hardfault during init of the code and library model never boots.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>