### PR TITLE
Do not attempt to reset locked regions

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/native_drivers/spu.h
+++ b/platform/ext/target/nordic_nrf/common/core/native_drivers/spu.h
@@ -40,14 +40,14 @@ void spu_enable_interrupts(void);
 void spu_clear_events(void);
 
 /**
- * \brief Reset all memory regions to being Secure
+ * \brief Reset TF-M memory regions to being Secure.
  *
- * Reset all (Flash or SRAM) memory regions to being Secure
- * and have default (i.e. Read-Write-Execute allow) access policy
+ * Reset all (Flash or SRAM, but excluding the regions owned by the bootloader(s)) memory region permissions
+ to be Secure and have default (i.e. Read-Write-Execute allow) access policy.
  *
  * \note region lock is not applied to allow modifying the configuration.
  */
-void spu_regions_reset_all_secure(void);
+void spu_regions_reset_unlocked_secure(void);
 
 /**
  * \brief Configure Flash memory regions as Non-Secure
@@ -57,7 +57,7 @@ void spu_regions_reset_all_secure(void);
  * \note region lock is applied to prevent further modification during
  * the current reset cycle.
  */
-void spu_regions_flash_config_non_secure( uint32_t start_addr, uint32_t limit_addr);
+void spu_regions_flash_config_non_secure(uint32_t start_addr, uint32_t limit_addr);
 
 /**
  * \brief Configure SRAM memory regions as Non-Secure
@@ -67,7 +67,7 @@ void spu_regions_flash_config_non_secure( uint32_t start_addr, uint32_t limit_ad
  * \note region lock is applied to prevent further modification during
  * the current reset cycle.
  */
-void spu_regions_sram_config_non_secure( uint32_t start_addr, uint32_t limit_addr);
+void spu_regions_sram_config_non_secure(uint32_t start_addr, uint32_t limit_addr);
 
 /**
  * \brief Configure Non-Secure Callable area

--- a/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/target_cfg.c
@@ -654,11 +654,10 @@ enum tfm_plat_err_t spu_init_cfg(void)
      * Configure Non-Secure Storage Partition
      */
 
-    /* Explicitly reset Flash and SRAM configuration to all-Secure,
-     * in case this has been overwritten by earlier images e.g.
-     * bootloader.
+    /* Reset Flash and SRAM configuration of regions that are not owned by
+     * the bootloader(s) to all-Secure.
      */
-    spu_regions_reset_all_secure();
+    spu_regions_reset_unlocked_secure();
 
     /* Configures SPU Code and Data regions to be non-secure */
     spu_regions_flash_config_non_secure(memory_regions.non_secure_partition_base,

--- a/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/target_cfg.c
@@ -529,11 +529,10 @@ enum tfm_plat_err_t spu_init_cfg(void)
      * Configure Non-Secure Storage Partition
      */
 
-    /* Explicitly reset Flash and SRAM configuration to all-Secure,
-     * in case this has been overwritten by earlier images e.g.
-     * bootloader.
+    /* Reset Flash and SRAM configuration of regions that are not owned by
+     * the bootloader(s) to all-Secure.
      */
-    spu_regions_reset_all_secure();
+    spu_regions_reset_unlocked_secure();
 
     /* Configures SPU Code and Data regions to be non-secure */
     spu_regions_flash_config_non_secure(memory_regions.non_secure_partition_base,


### PR DESCRIPTION
With a bootloader enabled some regions are locked and cannot be reset by TF-M. This commit checks whether the region is locked before resetting them.