### PR TITLE
[nrf noup] Fix configurable stack size in non-NCS build

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf5340/partition/region_defs.h
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/partition/region_defs.h
@@ -20,6 +20,8 @@
 
 #include "flash_layout.h"
 
+#define CRYPTO_STACK_SIZE       (0x2000)
+
 #define BL2_HEAP_SIZE           (0x00001000)
 #define BL2_MSP_STACK_SIZE      (0x00001800)
 

--- a/platform/ext/target/nordic_nrf/common/nrf9160/partition/region_defs.h
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/partition/region_defs.h
@@ -20,6 +20,8 @@
 
 #include "flash_layout.h"
 
+#define CRYPTO_STACK_SIZE       (0x2000)
+
 #define BL2_HEAP_SIZE           (0x00001000)
 #define BL2_MSP_STACK_SIZE      (0x00001800)
 


### PR DESCRIPTION
fixup! [nrf noup] Add configurable stack size for crypto partition.

Add missing definition of CRYPTO_STACK_SIZE when NCS TF-M is built in vanilla TF-M configuration.
This is useful in testing scenarios when sending patches upstream.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>