### PR TITLE
[nrf toup]: ITS: Add support for encrypted ITS

### DIFF
--- a/config/config_base.cmake
+++ b/config/config_base.cmake
@@ -108,6 +108,9 @@ set(PS_ENCRYPTION                       ON          CACHE BOOL      "Enable encr
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
 
 set(TFM_PARTITION_INTERNAL_TRUSTED_STORAGE OFF      CACHE BOOL      "Enable Internal Trusted Storage partition")
+set(TFM_ITS_ENCRYPTED                   OFF         CACHE BOOL      "Enable authenticated encryption of ITS files using platform specific APIs")
+set(TFM_ITS_AUTH_TAG_LENGTH             "16"        CACHE STRING    "The size of the authentication tag used when authentication/encryption of ITS files is enabled ")
+set(TFM_ITS_ENC_NONCE_LENGTH            "12"        CACHE STRING    "The size of the nonce used when ITS file encryption is enabled")
 
 set(TFM_PARTITION_CRYPTO                OFF         CACHE BOOL      "Enable Crypto partition")
 set(CRYPTO_TFM_BUILTIN_KEYS_DRIVER      ON          CACHE BOOL      "Whether to allow crypto service to store builtin keys. Without this, ALL builtin keys must be stored in a platform-specific location")

--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -74,6 +74,7 @@ target_sources(platform_s
         native_drivers/mpu_armv8m_drv.c
         native_drivers/spu.c
         $<$<OR:$<BOOL:${TFM_S_REG_TEST}>,$<BOOL:${TFM_NS_REG_TEST}>>:${CMAKE_CURRENT_SOURCE_DIR}/plat_test.c>
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:${CMAKE_CURRENT_SOURCE_DIR}/tfm_hal_its_encryption.c>
 )
 
 if (NRF_HW_INIT_RESET_ON_BOOT)

--- a/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption.c
+++ b/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption.c
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "platform/include/tfm_platform_system.h"
+#include "platform/include/tfm_hal_its.h"
+#include "psa/crypto.h"
+#include <string.h>
+#include <stdint>
+
+/* The cc3xx driver is used directly in this file as the PSA APIs depends on
+ * ITS, so using PSA APIs would result in circular dependencies
+ */
+#include "nrf_cc3xx_platform_derived_key.h"
+#include "nrf_cc3xx_platform.h"
+#include "nrf_cc3xx_platform_kmu.h"
+
+#define ITS_ENCRYPTION_SUCCESS 0
+
+#define HUK_KMU_SLOT 2
+#define HUK_KMU_SIZE_BITS 128
+
+/* Global encryption counter which resets per boot. The counter ensures that
+ * the nonce will not be identical for consecutive file writes during the same
+ * boot.
+ */
+static uint32_t g_enc_counter;
+
+/* The global nonce seed which is fetched once in every boot. The seed is used
+ * as part of the nonce and allows the platforms to diversify their nonces
+ * across resets. Note that the way that this seed is generated is platform
+ * specific, so the diversification is optional.
+ */
+static uint8_t g_enc_nonce_seed[TFM_ITS_ENC_NONCE_LENGTH -
+                                sizeof(g_enc_counter)];
+
+/* TFM_ITS_ENC_NONCE_LENGTH is configurable but this implementation expects
+ * the seed to be 8 bytes and the nonce length to be 12.
+ */
+#if TFM_ITS_ENC_NONCE_LENGTH != 12
+#error "This implementation only supports a ITS nonce of size 12"
+#endif
+
+/*
+ * This implementation doesn't use monotonic counters, but therfore a 64 bit
+ * seed combined with a counter, that gets reset on each reboot.
+ * This still has the risk of getting a collision on the seed resulting in
+ * nonce's beeing the same after a reboot.
+*/
+enum tfm_hal_status_t tfm_hal_its_aead_generate_nonce(uint8_t *nonce,
+                                                      size_t nonce_size)
+{
+    int err;
+
+    if(nonce == NULL){
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    if(nonce_size < sizeof(g_enc_nonce_seed) + sizeof(g_enc_counter)){
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    /* To avoid wrap-around of the g_enc_counter and subsequent re-use of the
+     * nonce we check the counter value for its max value
+     */
+    if(g_enc_counter ==  UINT32_MAX) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
+    if (g_enc_counter == 0) {
+        err = nrf_cc3xx_platform_get_nonce_seed(g_enc_nonce_seed);
+        if (err != 0) {
+            return TFM_HAL_ERROR_GENERIC;
+        }
+    }
+
+    memcpy(nonce, g_enc_nonce_seed, sizeof(g_enc_nonce_seed));
+    memcpy(nonce + sizeof(g_enc_nonce_seed),
+               &g_enc_counter,
+               sizeof(g_enc_counter));
+
+    g_enc_counter++;
+
+    return TFM_HAL_SUCCESS;
+}
+
+enum tfm_hal_status_t tfm_hal_its_aead_set_deriv_label(
+                                        struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                        uint8_t *deriv_label,
+                                        size_t deriv_label_size)
+{
+    if (ctx == NULL || deriv_label == NULL) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    ctx->deriv_label = deriv_label;
+    ctx->deriv_label_size = deriv_label_size;
+
+    return TFM_HAL_SUCCESS;
+}
+
+enum tfm_hal_status_t tfm_hal_its_aead_set_nonce(
+                                        struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                        uint8_t *nonce,
+                                        size_t nonce_size)
+{
+    if (ctx == NULL || nonce == NULL) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    ctx->nonce = nonce;
+    ctx->nonce_size = nonce_size;
+
+    return TFM_HAL_SUCCESS;
+}
+
+enum tfm_hal_status_t tfm_hal_its_aead_set_ad(
+                                        struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                        uint8_t *ad,
+                                        size_t ad_size) {
+
+    if (ctx == NULL) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    if (ad == NULL && ad_size != 0) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    ctx->add = ad;
+    ctx->add_size = ad_size;
+
+    return TFM_HAL_SUCCESS;
+}
+
+
+static bool ctx_is_valid(struct tfm_hal_its_auth_crypt_ctx *ctx)
+{
+    bool ret;
+
+    if (ctx == NULL) {
+        return false;
+    }
+
+    ret = (ctx->deriv_label == NULL && ctx->deriv_label_size != 0) ||
+          (ctx->add == NULL && ctx->add_size != 0) ||
+          (ctx->nonce == NULL && ctx->nonce_size != 0);
+
+    return !ret;
+}
+
+static enum tfm_hal_status_t tfm_hal_its_aead_init(
+                            struct tfm_hal_its_auth_crypt_ctx *ctx,
+                            nrf_cc3xx_platform_derived_key_ctx_t *platform_ctx,
+                            uint8_t *tag,
+                            size_t tag_size)
+{
+
+    int err = NRF_CC3XX_PLATFORM_ERROR_INTERNAL;
+
+
+    err = nrf_cc3xx_platform_derived_key_init(platform_ctx);
+    if (err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
+    err = nrf_cc3xx_platform_derived_key_set_info(platform_ctx,
+                                                  HUK_KMU_SLOT,
+                                                  HUK_KMU_SIZE_BITS,
+                                                  ctx->deriv_label,
+                                                  ctx->deriv_label_size);
+    if (err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    err = nrf_cc3xx_platform_derived_key_set_cipher(platform_ctx,
+                                                    ALG_CHACHAPOLY_256_BIT);
+
+    if (err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    err = nrf_cc3xx_platform_derived_key_set_auth_info(platform_ctx,
+                                                       ctx->nonce,
+                                                       ctx->nonce_size,
+                                                       ctx->add,
+                                                       ctx->add_size,
+                                                       tag,
+                                                       tag_size);
+    if (err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    return TFM_HAL_SUCCESS;
+}
+
+static void tfm_hal_its_aead_cleanup(
+                            nrf_cc3xx_platform_derived_key_ctx_t *platform_ctx)
+{
+    if(platform_ctx != NULL){
+        memset(platform_ctx,
+                   0x0,
+                   sizeof(nrf_cc3xx_platform_derived_key_ctx_t));
+    }
+}
+
+enum tfm_hal_status_t tfm_hal_its_aead_encrypt(
+                                        struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                        uint8_t *plaintext,
+                                        size_t plaintext_size,
+                                        uint8_t *ciphertext,
+                                        size_t ciphertext_size,
+                                        uint8_t *tag,
+                                        size_t tag_size)
+{
+    nrf_cc3xx_platform_derived_key_ctx_t platform_ctx = {0};
+    enum tfm_hal_status_t err = TFM_HAL_ERROR_GENERIC;
+    int plat_err = NRF_CC3XX_PLATFORM_ERROR_INTERNAL;
+
+    if (!ctx_is_valid(ctx) || tag == NULL) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    if (plaintext_size > ciphertext_size) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    err = tfm_hal_its_aead_init(ctx,
+                                &platform_ctx,
+                                tag,
+                                tag_size);
+    if (err !=  TFM_HAL_SUCCESS) {
+        tfm_hal_its_aead_cleanup(&platform_ctx);
+        return err;
+    }
+
+
+    plat_err = nrf_cc3xx_platform_derived_key_encrypt(&platform_ctx,
+                                                      ciphertext,
+                                                      plaintext_size,
+                                                      plaintext);
+
+    tfm_hal_its_aead_cleanup(&platform_ctx);
+
+    if (plat_err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
+    return TFM_HAL_SUCCESS;
+}
+
+enum tfm_hal_status_t tfm_hal_its_aead_decrypt(
+                                        struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                        uint8_t *ciphertext,
+                                        size_t ciphertext_size,
+                                        uint8_t *tag,
+                                        size_t tag_size,
+                                        uint8_t *plaintext,
+                                        size_t plaintext_size)
+{
+    nrf_cc3xx_platform_derived_key_ctx_t platform_ctx = {0};
+    enum tfm_hal_status_t err = TFM_HAL_ERROR_GENERIC;
+    int plat_err = NRF_CC3XX_PLATFORM_ERROR_INTERNAL;
+
+    if (!ctx_is_valid(ctx) || tag == NULL) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    if (plaintext_size < ciphertext_size) {
+        return TFM_HAL_ERROR_INVALID_INPUT;
+    }
+
+    err = tfm_hal_its_aead_init(ctx,
+                                &platform_ctx,
+                                tag,
+                                tag_size);
+    if (err != TFM_HAL_SUCCESS) {
+        tfm_hal_its_aead_cleanup(&platform_ctx);
+        return err;
+    }
+
+
+    plat_err = nrf_cc3xx_platform_derived_key_decrypt(&platform_ctx,
+                                                      plaintext,
+                                                      ciphertext_size,
+                                                      ciphertext);
+    tfm_hal_its_aead_cleanup(&platform_ctx);
+
+    if (plat_err != NRF_CC3XX_PLATFORM_SUCCESS) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
+    return TFM_HAL_SUCCESS;
+}
+

--- a/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption.h
+++ b/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+
+/**
+ * \brief Struct containing information required from the platform to perform
+ *        encryption/decryption of ITS files.
+ */
+struct tfm_hal_its_auth_crypt_ctx{
+    uint8_t *deriv_label;    /* The derivation label for AEAD */
+    size_t deriv_label_size; /* Size of the deriv_label in bytes */
+    uint8_t *add;            /* The additional authenticated data for AEAD */
+    size_t add_size;         /* Size of the add in bytes */
+    uint8_t *nonce;          /* The nonce for AEAD */
+    size_t nonce_size;       /* Size of the nonce in bytes */
+};
+

--- a/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/CMakeLists.txt
@@ -49,6 +49,9 @@ target_compile_definitions(platform_s
     PUBLIC
         NRF5340_XXAA_APPLICATION
         NRF_SKIP_FICR_NS_COPY_TO_RAM
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_ENCRYPTED>
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_ENC_NONCE_LENGTH=${TFM_ITS_ENC_NONCE_LENGTH}>
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_AUTH_TAG_LENGTH=${TFM_ITS_AUTH_TAG_LENGTH}>
 )
 
 #========================= Platform Non-Secure ================================#

--- a/platform/ext/target/nordic_nrf/common/nrf5340/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/config.cmake
@@ -13,3 +13,5 @@ set(PSA_API_TEST_TARGET                 "nrf5340"  CACHE STRING    "PSA API test
 set(NRF_NS_STORAGE                      OFF        CACHE BOOL      "Enable non-secure storage partition")
 set(BL2                                 ON         CACHE BOOL      "Whether to build BL2")
 set(NRF_NS_SECONDARY                    ${BL2}     CACHE BOOL      "Enable non-secure secondary partition")
+set(TFM_ITS_ENC_NONCE_LENGTH            "12"       CACHE STRING    "The size of the nonce used in ITS encryption in bytes")
+set(TFM_ITS_AUTH_TAG_LENGTH             "16"       CACHE STRING    "The size of the tag used in ITS encryption in bytes")

--- a/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/CMakeLists.txt
@@ -49,6 +49,9 @@ target_compile_definitions(platform_s
     PUBLIC
         NRF9160_XXAA
         NRF_SKIP_FICR_NS_COPY_TO_RAM
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_ENCRYPTED>
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_ENC_NONCE_LENGTH=${TFM_ITS_ENC_NONCE_LENGTH}>
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:TFM_ITS_AUTH_TAG_LENGTH=${TFM_ITS_AUTH_TAG_LENGTH}>
 )
 
 #========================= Platform Non-Secure ================================#

--- a/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf9160/config.cmake
@@ -13,3 +13,5 @@ set(PSA_API_TEST_TARGET                 "nrf9160"  CACHE STRING    "PSA API test
 set(NRF_NS_STORAGE                      OFF        CACHE BOOL      "Enable non-secure storage partition")
 set(BL2                                 ON         CACHE BOOL      "Whether to build BL2")
 set(NRF_NS_SECONDARY                    ${BL2}     CACHE BOOL      "Enable non-secure secondary partition")
+set(TFM_ITS_ENC_NONCE_LENGTH            "12"       CACHE STRING    "The size of the nonce used in ITS encryption in bytes")
+set(TFM_ITS_AUTH_TAG_LENGTH             "16"       CACHE STRING    "The size of the tag used in ITS encryption in bytes")

--- a/platform/include/tfm_hal_its.h
+++ b/platform/include/tfm_hal_its.h
@@ -15,6 +15,11 @@
 #include "Driver_Flash.h"
 #include "flash_layout.h"
 #include "tfm_hal_defs.h"
+#include "psa/crypto.h"
+
+#ifdef TFM_ITS_ENCRYPTED
+#include "tfm_hal_its_encryption.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -72,6 +77,119 @@ extern ARM_DRIVER_FLASH TFM_HAL_ITS_FLASH_DRIVER;
  */
 enum tfm_hal_status_t
 tfm_hal_its_fs_info(struct tfm_hal_its_fs_info_t *fs_info);
+
+#ifdef TFM_ITS_ENCRYPTED
+
+/**
+ * \brief Generate an encryption nonce
+ *
+ * \details The nonce has to be unique for every encryption using the same key,
+ *          even across resets.
+ * \param [out] nonce           Pointer to the nonce
+ * \param [in]  nonce_size      Size of the nonce in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ * \retval TFM_HAL_ERROR_GENERIC       Failed to fill the nonce seed because of
+ *                                     an internal error
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_generate_nonce(uint8_t *nonce,
+                                                      size_t nonce_size);
+
+/**
+ * \brief Set the derivation label for the AEAD operation.
+ *
+ * \param [in] ctx               AEAD context for ITS object
+ * \param [in] deriv_label       Pointer to the derivation label
+ * \param [in] derive_label_size Size of the derivation label in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_set_deriv_label(
+                                         struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                         uint8_t *deriv_label,
+                                         size_t deriv_label_size);
+
+/**
+ * \brief Set the nonce for the AEAD operation.
+ *
+ * \param [in] ctx        AEAD context for ITS object
+ * \param [in] nonce      Pointer to the nonce
+ * \param [in] nonce_size Size of the nonce in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_set_nonce(
+                                         struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                         uint8_t *nonce,
+                                         size_t nonce_size);
+
+/**
+ * \brief Set the pointer to the additional authenticated data for the AEAD operation.
+ *
+ * \param [in] ctx      AEAD context for ITS object
+ * \param [in] ad       Pointer to the additional data
+ * \param [in] ad_size  Size of the additional data in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_set_ad(
+                                         struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                         uint8_t *ad,
+                                         size_t ad_size);
+
+/**
+ * \brief Perform authenticated encryption.
+ *
+ * \param [in]  ctx               AEAD context for ITS object
+ * \param [in]  plaintext         Pointer to the plaintext
+ * \param [in]  plaintext_size    Size of the plaintext in bytes
+ * \param [out] ciphertext        Pointer to the ciphertext
+ * \param [in]  ciphertext_size   Size of the ciphertext in bytes
+ * \param [out] tag               Authentication tag
+ * \param [in]  tag_size          Authentication tag size in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ * \retval TFM_HAL_ERROR_GENERIC       Failed to encrypt
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_encrypt(
+                                         struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                         uint8_t *plaintext,
+                                         size_t plaintext_size,
+                                         uint8_t *ciphertext,
+                                         size_t ciphertext_size,
+                                         uint8_t *tag,
+                                         size_t tag_size);
+
+/**
+ * \brief Perform authenticated decryption.
+ *
+ * \param [in]  ctx               AEAD context for ITS object
+ * \param [in]  ciphertext        Pointer to the ciphertext
+ * \param [in]  ciphertext_size   Size of the ciphertext in bytes
+ * \param [in]  tag               Authentication tag
+ * \param [in]  tag_size          Authentication tag size in bytes
+ * \param [out] plaintext         Pointer to the plaintext
+ * \param [in]  plaintext_size    Size of the plaintext in bytes
+ *
+ * \retval TFM_HAL_SUCCESS             The operation completed successfully
+ * \retval TFM_HAL_ERROR_INVALID_INPUT Invalid argument
+ * \retval TFM_HAL_ERROR_GENERIC       Failed to decrypt
+ */
+enum tfm_hal_status_t tfm_hal_its_aead_decrypt(
+                                         struct tfm_hal_its_auth_crypt_ctx *ctx,
+                                         uint8_t *ciphertext,
+                                         size_t ciphertext_size,
+                                         uint8_t *tag,
+                                         size_t tag_size,
+                                         uint8_t *plaintext,
+                                         size_t plaintext_size);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/secure_fw/partitions/internal_trusted_storage/CMakeLists.txt
+++ b/secure_fw/partitions/internal_trusted_storage/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(tfm_psa_rot_partition_its
         tfm_its_req_mngr.c
         tfm_internal_trusted_storage.c
         its_utils.c
+        $<$<BOOL:${TFM_ITS_ENCRYPTED}>:its_crypto_interface.c>
         flash/its_flash.c
         flash/its_flash_nand.c
         flash/its_flash_nor.c

--- a/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.c
+++ b/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.c
@@ -237,6 +237,11 @@ psa_status_t its_flash_fs_file_get_info(struct its_flash_fs_ctx_t *fs_ctx,
     info->size_current = tmp_metadata.cur_size;
     info->flags = tmp_metadata.flags & ITS_FLASH_FS_USER_FLAGS_MASK;
 
+#ifdef TFM_ITS_ENCRYPTED
+    memcpy(info->nonce, tmp_metadata.nonce, TFM_ITS_ENC_NONCE_LENGTH);
+    memcpy(info->tag, tmp_metadata.tag, TFM_ITS_AUTH_TAG_LENGTH);
+#endif
+
     return PSA_SUCCESS;
 }
 
@@ -369,6 +374,11 @@ psa_status_t its_flash_fs_file_write(struct its_flash_fs_ctx_t *fs_ctx,
     if (err != PSA_SUCCESS) {
         return PSA_ERROR_GENERIC_ERROR;
     }
+
+#ifdef TFM_ITS_ENCRYPTED
+    memcpy(file_meta.nonce, finfo->nonce, sizeof(finfo->nonce));
+    memcpy(file_meta.tag, finfo->tag, sizeof(finfo->tag));
+#endif
 
     /* Write file metadata in the scratch metadata block */
     err = its_flash_fs_mblock_update_scratch_file_meta(fs_ctx, new_idx,

--- a/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.h
+++ b/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.h
@@ -179,6 +179,12 @@ struct its_flash_fs_file_info_t {
     size_t size_current;  /*!< The current size of the file in bytes */
     size_t size_max;      /*!< The maximum size of the file in bytes. */
     uint32_t flags;       /*!< Flags set when the file was created */
+#ifdef TFM_ITS_ENCRYPTED
+    /*!< Additional authenticated data */
+    uint8_t add[ITS_FILE_ID_SIZE + ITS_DATA_SIZE_FIELD_SIZE + ITS_FLAG_SIZE];
+    uint8_t nonce[TFM_ITS_ENC_NONCE_LENGTH];/*!< Nonce/IV for encrypted files */
+    uint8_t tag[TFM_ITS_AUTH_TAG_LENGTH];   /*!< Authentication tag */
+#endif
 };
 
 /**

--- a/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.h
+++ b/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs.h
@@ -167,15 +167,18 @@ struct its_flash_fs_ops_t {
 typedef struct its_flash_fs_ctx_t its_flash_fs_ctx_t;
 
 /*!
- * \struct its_file_info_t
+ * \struct its_flash_fs_file_info_t
  *
- * \brief Structure to store the file information.
+ * \brief Structure containing file information.
+ *
+ * \details This structure is not written to the filesystem, it is used by the
+ *          file system functions to simplify accessing the containing
+ *          information.
  */
-struct its_file_info_t {
-    size_t size_current; /*!< The current size of the flash file data */
-    size_t size_max;     /*!< The maximum size of the flash file data in bytes.
-                          */
-    uint32_t flags;      /*!< Flags set when the file was created */
+struct its_flash_fs_file_info_t {
+    size_t size_current;  /*!< The current size of the file in bytes */
+    size_t size_max;      /*!< The maximum size of the file in bytes. */
+    uint32_t flags;       /*!< Flags set when the file was created */
 };
 
 /**
@@ -233,23 +236,21 @@ psa_status_t its_flash_fs_file_exist(its_flash_fs_ctx_t *fs_ctx,
  *
  * \param[in,out] fs_ctx  Filesystem context
  * \param[in]     fid     File ID
- * \param[out]    info    Pointer to the information structure to store the
- *                        file information values \ref its_file_info_t
+ * \param[out]    info    Pointer to the file information
+ *                        structure \ref its_flash_fs_file_info_t
  *
  * \return Returns error code specified in \ref psa_status_t
  */
 psa_status_t its_flash_fs_file_get_info(its_flash_fs_ctx_t *fs_ctx,
                                         const uint8_t *fid,
-                                        struct its_file_info_t *info);
+                                        struct its_flash_fs_file_info_t *info);
 
 /**
  * \brief Writes data to a file.
  *
  * \param[in,out] fs_ctx     Filesystem context
  * \param[in]     fid        File ID
- * \param[in]     flags      Flags of the file
- * \param[in]     max_size   Maximum size of the file to be created. Ignored if
- *                           the file is not being created.
+ * \param[in]     finfo      Pointer to \ref its_flash_fs_file_info_t
  * \param[in]     data_size  Size of the incoming write data.
  * \param[in]     offset     Offset in the file to write. Must be less than or
  *                           equal to the current file size.
@@ -259,8 +260,7 @@ psa_status_t its_flash_fs_file_get_info(its_flash_fs_ctx_t *fs_ctx,
  */
 psa_status_t its_flash_fs_file_write(its_flash_fs_ctx_t *fs_ctx,
                                      const uint8_t *fid,
-                                     uint32_t flags,
-                                     size_t max_size,
+                                     struct its_flash_fs_file_info_t *finfo,
                                      size_t data_size,
                                      size_t offset,
                                      const uint8_t *data);

--- a/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs_mblock.h
+++ b/secure_fw/partitions/internal_trusted_storage/flash_fs/its_flash_fs_mblock.h
@@ -142,6 +142,14 @@ struct its_block_meta_t {
 };
 #undef _T2
 
+#ifdef TFM_ITS_ENCRYPTED
+    #define _T3_AUTH_ENC_META \
+    uint8_t nonce[TFM_ITS_ENC_NONCE_LENGTH]; \
+    uint8_t tag[TFM_ITS_AUTH_TAG_LENGTH];
+#else
+    #define _T3_AUTH_ENC_META
+#endif
+
 /*!
  * \struct its_file_meta_t
  *
@@ -160,7 +168,8 @@ struct its_block_meta_t {
                                     */ \
     size_t max_size;               /*!< Maximum size of this file */ \
     uint32_t flags;                /*!< Flags set when the file was created */ \
-    uint8_t id[ITS_FILE_ID_SIZE];  /*!< ID of this file */
+    uint8_t id[ITS_FILE_ID_SIZE];  /*!< ID of this file */ \
+    _T3_AUTH_ENC_META
 
 struct its_file_meta_t {
     _T3

--- a/secure_fw/partitions/internal_trusted_storage/its_crypto_interface.c
+++ b/secure_fw/partitions/internal_trusted_storage/its_crypto_interface.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2019-2021, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "tfm_internal_trusted_storage.h"
+
+#include "tfm_hal_its.h"
+#include "tfm_hal_ps.h"
+#include "flash/its_flash.h"
+#include "flash_fs/its_flash_fs.h"
+#include "psa_manifest/pid.h"
+#include "tfm_its_defs.h"
+#include "its_utils.h"
+#include "tfm_sp_log.h"
+#include <string.h>
+
+/**
+ * \brief Fills the AEAD additional data used for the encryption/decryption
+ *
+ * \details The additional data are not encypted their integrity is checked.
+ *          For the ITS encryption we use the file id, the file flags and the
+ *          data size of the file as addditional data.
+ *
+ * \param[out]  add       Additional data
+ * \param[in]   add_size  Additional data size in bytes
+ * \param[in]   fid       Identifier of the file
+ * \param[in]   fid_size  Identifier of the file size in bytes
+ * \param[in]   flags     Flags of the file
+ * \param[in]   data_size Data size in bytes
+ *
+ * \retval PSA_SUCCESS                On success
+ * \retval PSA_ERROR_INVALID_ARGUMENT When the addditional data buffer does not
+ *                                    have the correct size of the add/fid
+ *                                    buffers are NULL
+ *
+ */
+static psa_status_t tfm_its_fill_enc_add(uint8_t *add,
+                                         size_t add_size,
+                                         uint8_t *fid,
+                                         size_t fid_size,
+                                         uint32_t flags,
+                                         size_t data_size)
+
+{
+    /* Only the user flags are populated in the function which
+     * gets the file info from ITS (see its_flash_fs_file_get_info).
+     * We use the same flags for comformity.
+     */
+    uint32_t user_flags = flags & ITS_FLASH_FS_USER_FLAGS_MASK;
+
+    /* The additional data consist of the file id, the flags and the
+     * data size of the file.
+     */
+    size_t add_expected_size = ITS_FILE_ID_SIZE +
+                               sizeof(user_flags) +
+                               sizeof(data_size);
+
+    if (add_size != add_expected_size || add == NULL || fid == NULL) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    memcpy(add, fid, fid_size);
+    memcpy(add + fid_size, &user_flags, sizeof(user_flags));
+    memcpy(add + fid_size + sizeof(user_flags),
+               &data_size,
+               sizeof(data_size));
+
+    return PSA_SUCCESS;
+}
+
+static psa_status_t tfm_hal_to_psa_error(enum tfm_hal_status_t tfm_hal_err){
+
+    switch (tfm_hal_err)
+    {
+    case TFM_HAL_SUCCESS:
+        return PSA_SUCCESS;
+        break;
+    case TFM_HAL_ERROR_INVALID_INPUT:
+        return PSA_ERROR_INVALID_ARGUMENT;
+        break;
+    default:
+        return PSA_ERROR_GENERIC_ERROR;
+        break;
+    }
+
+}
+
+psa_status_t tfm_its_crypt_file(struct its_flash_fs_file_info_t *finfo,
+                                uint8_t *fid,
+                                size_t fid_size,
+                                uint8_t *input,
+                                size_t input_size,
+                                uint8_t *output,
+                                size_t output_size,
+                                bool is_encrypt)
+{
+
+    struct tfm_hal_its_auth_crypt_ctx aead_ctx = {0};
+    enum tfm_hal_status_t err;
+    size_t file_size;
+
+    if (finfo == NULL) {
+        return PSA_ERROR_INVALID_ARGUMENT;
+    }
+
+    /* The file size is not known yet when encrypting */
+    if (is_encrypt){
+        file_size = input_size;
+    } else {
+        file_size = finfo->size_current;
+    }
+
+    err =  tfm_its_fill_enc_add(finfo->add,
+                                sizeof(finfo->add),
+                                fid,
+                                fid_size,
+                                finfo->flags,
+                                file_size);
+    if (err != TFM_HAL_SUCCESS) {
+        return tfm_hal_to_psa_error(err);
+    }
+
+    if (is_encrypt) {
+        err = tfm_hal_its_aead_generate_nonce(finfo->nonce,
+                                              sizeof(finfo->nonce));
+
+        if (err != TFM_HAL_SUCCESS) {
+            return tfm_hal_to_psa_error(err);
+        }
+    }
+
+
+    err = tfm_hal_its_aead_set_nonce(&aead_ctx,
+                                     finfo->nonce,
+                                     sizeof(finfo->nonce));
+    if (err != TFM_HAL_SUCCESS) {
+        return tfm_hal_to_psa_error(err);
+    }
+
+
+    err = tfm_hal_its_aead_set_deriv_label(&aead_ctx,
+                                           fid,
+                                           fid_size);
+    if (err != TFM_HAL_SUCCESS) {
+        return tfm_hal_to_psa_error(err);
+    }
+
+    err = tfm_hal_its_aead_set_ad(&aead_ctx,
+                                   finfo->add,
+                                   sizeof(finfo->add));
+    if (err != TFM_HAL_SUCCESS) {
+        return tfm_hal_to_psa_error(err);
+    }
+
+    if (is_encrypt) {
+        err = tfm_hal_its_aead_encrypt(&aead_ctx,
+                                       input,
+                                       input_size,
+                                       output,
+                                       output_size,
+                                       finfo->tag,
+                                       sizeof(finfo->tag));
+    } else {
+        err = tfm_hal_its_aead_decrypt(&aead_ctx,
+                                       input,
+                                       input_size,
+                                       finfo->tag,
+                                       sizeof(finfo->tag),
+                                       output,
+                                       output_size);
+    }
+
+    if (err != TFM_HAL_SUCCESS) {
+        return tfm_hal_to_psa_error(err);
+    }
+
+    if (is_encrypt) {
+        finfo->size_max = input_size;
+    }
+
+    return PSA_SUCCESS;
+}
+

--- a/secure_fw/partitions/internal_trusted_storage/its_crypto_interface.h
+++ b/secure_fw/partitions/internal_trusted_storage/its_crypto_interface.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019-2021, Arm Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "tfm_internal_trusted_storage.h"
+
+#include "tfm_hal_its.h"
+#include "tfm_hal_ps.h"
+#include "flash/its_flash.h"
+#include "flash_fs/its_flash_fs.h"
+#include "psa_manifest/pid.h"
+#include "tfm_its_defs.h"
+#include "its_utils.h"
+#include "tfm_sp_log.h"
+
+/**
+ * \brief Perform encryption/decryption of the buffer using the
+ *        tfm_hal_its_aead APIs
+ *
+ * \param[in]   finfo         Pointer to \ref its_flash_fs_file_info_t
+ * \param[in]   fid           File identifier
+ * \param[in]   fid_size      File identifier size in bytes
+ * \param[in]   input         Input buffer
+ * \param[in]   input_size    Input size in bytes
+ * \param[out]  output        Output buffer
+ * \param[in]   output_size   Output size in bytes
+ * \param[in]   is_encrypt    Set the operation type (encryption/decryption)
+ *
+ * \return PSA_SUCCESS on succesfull operation or a valid PSA error code
+ *
+ */
+psa_status_t tfm_its_crypt_file(struct its_flash_fs_file_info_t *finfo,
+                                uint8_t *fid,
+                                size_t fid_size,
+                                uint8_t *input,
+                                size_t input_size,
+                                uint8_t *output,
+                                size_t output_size,
+                                bool is_encrypt);
+

--- a/secure_fw/partitions/internal_trusted_storage/its_utils.h
+++ b/secure_fw/partitions/internal_trusted_storage/its_utils.h
@@ -18,6 +18,8 @@ extern "C" {
 #endif
 
 #define ITS_FILE_ID_SIZE 12
+#define ITS_DATA_SIZE_FIELD_SIZE 4
+#define ITS_FLAG_SIZE 4
 #define ITS_DEFAULT_EMPTY_BUFF_VAL 0
 
 /**

--- a/secure_fw/partitions/internal_trusted_storage/tfm_internal_trusted_storage.c
+++ b/secure_fw/partitions/internal_trusted_storage/tfm_internal_trusted_storage.c
@@ -21,7 +21,7 @@
 #endif
 
 static uint8_t g_fid[ITS_FILE_ID_SIZE];
-static struct its_file_info_t g_file_info;
+static struct its_flash_fs_file_info_t g_file_info;
 
 static its_flash_fs_ctx_t fs_ctx_its;
 static struct its_flash_fs_config_t fs_cfg_its = {
@@ -265,13 +265,15 @@ psa_status_t tfm_its_set(struct its_asset_info *asset_info,
             return status;
         }
 
-        create_flags |= ITS_FLASH_FS_FLAG_CREATE | ITS_FLASH_FS_FLAG_TRUNCATE;
+        g_file_info.size_max = max_size;
+        g_file_info.flags = (uint32_t)create_flags |
+                        ITS_FLASH_FS_FLAG_CREATE | ITS_FLASH_FS_FLAG_TRUNCATE;
     }
 
     /* Write to the file in the file system */
     status = its_flash_fs_file_write(get_fs_ctx(client_id),
                                      g_fid,
-                                     create_flags, max_size,
+                                     &g_file_info,
                                      size_to_write, offset, data_buf);
     if (status != PSA_SUCCESS) {
         return status;

--- a/secure_fw/partitions/internal_trusted_storage/tfm_internal_trusted_storage.h
+++ b/secure_fw/partitions/internal_trusted_storage/tfm_internal_trusted_storage.h
@@ -84,11 +84,11 @@ psa_status_t tfm_its_set(struct its_asset_info *asset_info,
 /**
  * \brief Retrieve data associated with a provided UID
  *
- * Retrieves up to `data_size` bytes of the data associated with `uid`, starting
- * at `data_offset` bytes from the beginning of the data. Upon successful
- * completion, the data will be placed in the `p_data` buffer, which must be at
- * least `data_size` bytes in size. The length of the data returned will be in
- * `p_data_length`. If `data_size` is 0, the contents of `p_data_length` will
+ * Retrieves up to `size_to_read` bytes of the data associated with `uid`, starting
+ * at `offset` bytes from the beginning of the data. Upon successful
+ * completion, the data will be placed in the `data_buf` buffer, which must be at
+ * least `size_to_read` bytes in size. The length of the data returned will be in
+ * `p_data_length`. If `size_to_read` is 0, the contents of `p_data_length` will
  * be set to zero.
  *
  * \param[in]  asset_info     The asset info include UID, client, etc...
@@ -113,7 +113,7 @@ psa_status_t tfm_its_set(struct its_asset_info *asset_info,
  *                                     `p_data_length`) is invalid, for example
  *                                     is `NULL` or references memory the
  *                                     caller cannot access. In addition, this
- *                                     can also happen if `data_offset` is
+ *                                     can also happen if `offset` is
  *                                     larger than the size of the data
  *                                     associated with `uid`.
  */


### PR DESCRIPTION
This adds the support for EITS again, which had to be reverted for the update to TF-M 1.7
As the upstream PR didn't get merged yet.

-Adds encryption and authentication support for ITS files 
-Encryption is optional and is enabled using a CMake variable
-The encryption implementation is platform dependent, the signatures of the functions are provided in this change

Ref: NCSDK-19574


Change-Id: Iea6ed79907f046a79ff7ff44ea2c7285ee14ddab