### PR TITLE
[nrf toup] ITS: Fix build warning when Encrypted ITS is not enabled

### DIFF
--- a/secure_fw/partitions/internal_trusted_storage/tfm_its_req_mngr.c
+++ b/secure_fw/partitions/internal_trusted_storage/tfm_its_req_mngr.c
@@ -34,6 +34,7 @@ static uint8_t __ALIGNED(4) asset_data[ITS_UTILS_ALIGN(ITS_BUF_SIZE,
 #endif
 
 
+#ifdef TFM_ITS_ENCRYPTED
 static psa_status_t buffer_size_check(int32_t client_id, size_t buffer_size) {
 /* The buffer check is only need if we don't use the input buffer directly */
 #if PSA_FRAMEWORK_HAS_MM_IOVEC != 1
@@ -52,6 +53,7 @@ static psa_status_t buffer_size_check(int32_t client_id, size_t buffer_size) {
 #endif /* PSA_FRAMEWORK_HAS_MM_IOVEC != 1 */
     return PSA_SUCCESS;
 }
+#endif /* TFM_ITS_ENCRYPTED */
 
 static psa_status_t tfm_its_set_req(const psa_msg_t *msg)
 {


### PR DESCRIPTION
fixup! [nrf toup]: ITS: Add support for encrypted ITS

Fix build warning when Encrypted ITS is not enabled: warning: 'buffer_size_check' defined but not used [-Wunused-function].