### PR TITLE
Revert "[nrf noup] secure_fw: Remove mbedtls_platform_set_printf call"

### DIFF
--- a/secure_fw/partitions/crypto/crypto_init.c
+++ b/secure_fw/partitions/crypto/crypto_init.c
@@ -280,12 +280,7 @@ static psa_status_t tfm_crypto_engine_init(void)
 
     /* mbedtls_printf is used to print messages including error information. */
 #if (TFM_PARTITION_LOG_LEVEL >= TFM_PARTITION_LOG_LEVEL_ERROR)
-    /* NCSDK-19569: We cannot enable this function because cc3xx library causes
-     * duplicate definition of some symbols.
-     * It is not needed because we have in platform.h:
-     * #define MBEDTLS_PLATFORM_STD_PRINTF   printf
-     */
-    // mbedtls_platform_set_printf(printf);
+    mbedtls_platform_set_printf(printf);
 #endif
 
     /* Initialise the crypto accelerator if one is enabled. If the driver API is


### PR DESCRIPTION
This reverts commit 35403fc74543fa0c51865b562b22a9759a6027de.