### PR TITLE
[nrf fromtree] platform: nordic_nrf: Update Nordic HAL to include nrf…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
+++ b/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
@@ -83,7 +83,7 @@ static int32_t ARM_USARTx_Initialize(ARM_USART_SignalEvent_t cb_event,
 
     uart_resources->tx_count = 0;
     uart_resources->rx_count = 0;
-    uart_resources->hal_cfg  = uart_resources->initial_config->hal_cfg;
+    uart_resources->hal_cfg  = uart_resources->initial_config->config;
     uart_resources->baudrate = uart_resources->initial_config->baudrate;
 
     uart_resources->initialized = true;
@@ -147,7 +147,7 @@ static int32_t ARM_USARTx_Send(const void *data, uint32_t num,
             }
         }
     } else {
-        nrfx_err_t err_code = nrfx_uarte_tx(&uart_resources->uarte, data, num);
+        nrfx_err_t err_code = nrfx_uarte_tx(&uart_resources->uarte, data, num, 0);
         if (err_code == NRFX_ERROR_BUSY) {
             return ARM_DRIVER_ERROR_BUSY;
         } else if (err_code != NRFX_SUCCESS) {
@@ -316,14 +316,14 @@ static ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus(void)
 
 #define DRIVER_USART(idx)                                                 \
     static nrfx_uarte_config_t UART##idx##_initial_config = {             \
-        .pseltxd  = RTE_USART##idx##_TXD_PIN,                             \
-        .pselrxd  = RTE_USART##idx##_RXD_PIN,                             \
-        .pselrts  = RTE_USART##idx##_RTS_PIN,                             \
-        .pselcts  = RTE_USART##idx##_CTS_PIN,                             \
+        .txd_pin  = RTE_USART##idx##_TXD_PIN,                             \
+        .rxd_pin  = RTE_USART##idx##_RXD_PIN,                             \
+        .rts_pin  = RTE_USART##idx##_RTS_PIN,                             \
+        .cts_pin  = RTE_USART##idx##_CTS_PIN,                             \
         .baudrate = NRF_UARTE_BAUDRATE_115200,                            \
         .interrupt_priority = NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY,     \
-        .hal_cfg  = {                                                     \
-            .hwfc   = RTE_USART##idx##_HWFC,                              \
+        .config  = {                                                     \
+            .hwfc   = NRF_UARTE_HWFC_DISABLED,                            \
             .parity = NRF_UARTE_PARITY_EXCLUDED,                          \
             .stop   = NRF_UARTE_STOP_ONE,                                 \
         },                                                                \

--- a/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
+++ b/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
@@ -241,6 +241,45 @@ void nrfx_critical_section_exit(void);
 
 //------------------------------------------------------------------------------
 
+/**
+ * @brief Macro for writing back cache lines associated with the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_WB(p_buffer, size) \
+    do {                              \
+        (void)p_buffer;               \
+        (void)size;                   \
+    } while (0)
+
+/**
+ * @brief Macro for invalidating cache lines associated with the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_INV(p_buffer, size) \
+    do {                               \
+        (void)p_buffer;                \
+        (void)size;                    \
+    } while (0)
+
+/**
+ * @brief Macro for writing back and invalidating cache lines associated with
+ *        the specified buffer.
+ *
+ * @param[in] p_buffer Pointer to the buffer.
+ * @param[in] size     Size of the buffer.
+ */
+#define NRFY_CACHE_WBINV(p_buffer, size) \
+    do {                                 \
+        (void)p_buffer;                  \
+        (void)size;                      \
+    } while (0)
+
+//------------------------------------------------------------------------------
+
 /** @brief Bitmask that defines DPPI channels that are reserved for use outside of the nrfx library. */
 #define NRFX_DPPI_CHANNELS_USED   0
 


### PR DESCRIPTION
…x 3.0.0

nrfx 3.0.0 requires to provide cache management macros in nrfx_glue.h implementation. Macros don't have to provide proper implementation as it's not needed for SoCs that are on the market.

nrfx 3.0.0 renames fields in UARTE configuration structure to be aligned with nrfx naming convention.

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/20747

Change-Id: Iff5b55dba810ca6d9b73da25d165d2a1e92a5908
Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>
Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>
(cherry picked from commit fc785ae7ea67e8abe40ac35a8e7dcacdaaab63fc)