### PR TITLE
[nrf noup] secure_fw: Fix compile error with ITS enabled PS disabled

### DIFF
--- a/secure_fw/partitions/internal_trusted_storage/config_its.h
+++ b/secure_fw/partitions/internal_trusted_storage/config_its.h
@@ -9,7 +9,9 @@
 #define __CONFIG_PARTITION_ITS_H__
 
 #include "config_tfm.h"
+#ifdef TFM_PARTITION_PROTECTED_STORAGE
 #include "config_ps.h"
+#endif
 
 /* Create flash FS if it doesn't exist for Internal Trusted Storage partition */
 #ifndef ITS_CREATE_FLASH_LAYOUT


### PR DESCRIPTION
Fix compilation error in the Internal Trusted Storage partition when disabling the Protected Storage partition.

This is a noup patch because the header files no longer exists in upstream.