### PR TITLE
crypto: Fix use of PSA config in PSA crypto interface headers

### DIFF
--- a/interface/include/psa/crypto.h
+++ b/interface/include/psa/crypto.h
@@ -12,6 +12,17 @@
 #ifndef PSA_CRYPTO_H
 #define PSA_CRYPTO_H
 
+/* In Mbed TLS, we would query the current config through inclusion of
+ * of mbedtls/build_info.h, but in TF-M, we don't rely on build_info.h
+ * hence we just include the current configuration if it has been passed
+ * through command line. These config defines are required in crypto_sizes.h
+ * to compute macros that define sizes which depend on algorithms supported
+ * by the implementation
+ */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
+#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
+#endif /* MBEDTLS_PSA_CRYPTO_CONFIG_FILE */
+
 #include <stddef.h>
 
 #ifdef __DOXYGEN_ONLY__

--- a/interface/include/psa/crypto_sizes.h
+++ b/interface/include/psa/crypto_sizes.h
@@ -107,12 +107,18 @@
 /* Note: for HMAC-SHA-3, the block size is 144 bytes for HMAC-SHA3-226,
  * 136 bytes for HMAC-SHA3-256, 104 bytes for SHA3-384, 72 bytes for
  * HMAC-SHA3-512. */
+#if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
 #if defined(PSA_WANT_ALG_SHA_512) || defined(PSA_WANT_ALG_SHA_384)
 #define PSA_HASH_MAX_SIZE 64
 #define PSA_HMAC_MAX_HASH_BLOCK_SIZE 128
 #else
 #define PSA_HASH_MAX_SIZE 32
 #define PSA_HMAC_MAX_HASH_BLOCK_SIZE 64
+#endif
+#else
+/* Without any PSA configuration we must assume the maximum size possible. */
+#define PSA_HASH_MAX_SIZE 64
+#define PSA_HMAC_MAX_HASH_BLOCK_SIZE 128
 #endif
 
 /** \def PSA_MAC_MAX_SIZE
@@ -209,6 +215,7 @@
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 0
 #endif
 #else /* defined(MBEDTLS_PSA_CRYPTO_CONFIG)  */
+/* Without any PSA configuration we must assume the maximum size possible. */
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 521
 #endif /* defined(MBEDTLS_PSA_CRYPTO_CONFIG)  */
 

--- a/interface/include/psa/crypto_sizes.h
+++ b/interface/include/psa/crypto_sizes.h
@@ -179,11 +179,6 @@
 /* The maximum size of an ECC key on this implementation, in bits.
  * This is a vendor-specific macro. */
 #if defined(MBEDTLS_PSA_CRYPTO_CONFIG)
-#if defined(MBEDTLS_PSA_CRYPTO_CONFIG_FILE)
-#include MBEDTLS_PSA_CRYPTO_CONFIG_FILE
-#else
-#include "psa/crypto_config.h"
-#endif
 #if defined(PSA_WANT_ECC_SECP_R1_521)
 #define PSA_VENDOR_ECC_MAX_CURVE_BITS 521
 #elif defined(PSA_WANT_ECC_BRAINPOOL_P_R1_512)


### PR DESCRIPTION
Fix use of PSA config in PSA crypto interface headers.

This PR addreses the issue that PSA_HASH_MAX_SIZE will default to 32 instead of 64 when PSA configurations are not available to the PSA headers.

This PR also aligns with upstream way to include PSA configuration headers, however NCS does not define the right configurations yet to make this optimal configuration.