### PR TITLE
startup_file_improvements: [nrf noup] platform: nordic_nrf: Bugfix in startup file

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/startup.h
+++ b/platform/ext/target/nordic_nrf/common/core/startup.h
@@ -27,6 +27,11 @@ void __PROGRAM_START(void) __NO_RETURN;
 __NO_RETURN void __attribute__((weak, alias("default_tfm_IRQHandler"))) handler_name(void);
 
 __NO_RETURN void Reset_Handler(void);
+__NO_RETURN void HardFault_Handler(void);
+__NO_RETURN void MemManage_Handler(void);
+__NO_RETURN void BusFault_Handler(void);
+__NO_RETURN void UsageFault_Handler(void);
+__NO_RETURN void SecureFault_Handler(void);
 
 void SPU_IRQHandler(void);
 

--- a/platform/ext/target/nordic_nrf/common/nrf5340/gcc/startup_nrf5340.c
+++ b/platform/ext/target/nordic_nrf/common/nrf5340/gcc/startup_nrf5340.c
@@ -82,6 +82,14 @@ DEFAULT_IRQ_HANDLER(USBREGULATOR_IRQHandler)
 DEFAULT_IRQ_HANDLER(KMU_IRQHandler)
 DEFAULT_IRQ_HANDLER(CRYPTOCELL_IRQHandler)
 
+#if defined(DOMAIN_NS) || defined(BL2)
+DEFAULT_IRQ_HANDLER(SPU_IRQHandler)
+DEFAULT_IRQ_HANDLER(HardFault_Handler)
+DEFAULT_IRQ_HANDLER(MemManage_Handler)
+DEFAULT_IRQ_HANDLER(BusFault_Handler)
+DEFAULT_IRQ_HANDLER(UsageFault_Handler)
+DEFAULT_IRQ_HANDLER(SecureFault_Handler)
+#else
 /*
  * Default IRQ handlers will usually be overriden as they are
  * weak. But due to the way TF-M links it's binary (doesn't use
@@ -89,13 +97,6 @@ DEFAULT_IRQ_HANDLER(CRYPTOCELL_IRQHandler)
  * out some IRQ handlers that we know will be overridden anyway to be
  * safe.
  */
-#if !(defined(DOMAIN_NS) || defined(BL2))
-DEFAULT_IRQ_HANDLER(SPU_IRQHandler)
-DEFAULT_IRQ_HANDLER(HardFault_Handler)
-DEFAULT_IRQ_HANDLER(MemManage_Handler)
-DEFAULT_IRQ_HANDLER(BusFault_Handler)
-DEFAULT_IRQ_HANDLER(UsageFault_Handler)
-DEFAULT_IRQ_HANDLER(SecureFault_Handler)
 #endif
 
 #if defined ( __GNUC__ )

--- a/platform/ext/target/nordic_nrf/common/nrf91/gcc/startup_nrf91.c
+++ b/platform/ext/target/nordic_nrf/common/nrf91/gcc/startup_nrf91.c
@@ -72,6 +72,14 @@ DEFAULT_IRQ_HANDLER(GPIOTE1_IRQHandler)
 DEFAULT_IRQ_HANDLER(KMU_IRQHandler)
 DEFAULT_IRQ_HANDLER(CRYPTOCELL_IRQHandler)
 
+#if defined(DOMAIN_NS) || defined(BL2)
+DEFAULT_IRQ_HANDLER(SPU_IRQHandler)
+DEFAULT_IRQ_HANDLER(HardFault_Handler)
+DEFAULT_IRQ_HANDLER(MemManage_Handler)
+DEFAULT_IRQ_HANDLER(BusFault_Handler)
+DEFAULT_IRQ_HANDLER(UsageFault_Handler)
+DEFAULT_IRQ_HANDLER(SecureFault_Handler)
+#else
 /*
  * Default IRQ handlers will usually be overriden as they are
  * weak. But due to the way TF-M links it's binary (doesn't use
@@ -79,13 +87,6 @@ DEFAULT_IRQ_HANDLER(CRYPTOCELL_IRQHandler)
  * out some IRQ handlers that we know will be overridden anyway to be
  * safe.
  */
-#if !(defined(DOMAIN_NS) || defined(BL2))
-DEFAULT_IRQ_HANDLER(SPU_IRQHandler)
-DEFAULT_IRQ_HANDLER(HardFault_Handler)
-DEFAULT_IRQ_HANDLER(MemManage_Handler)
-DEFAULT_IRQ_HANDLER(BusFault_Handler)
-DEFAULT_IRQ_HANDLER(UsageFault_Handler)
-DEFAULT_IRQ_HANDLER(SecureFault_Handler)
 #endif
 
 #if defined ( __GNUC__ )


### PR DESCRIPTION
Fix a bug in the startup file where the ifdef was incorrectly negated.

Also add declarations for when the default irq handler is not used.