### PR TITLE
[nrf noup] platform: nrf_nordic: Add temp fix for for secure FPU on 9161

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf91/nrfx_config_nrf91.h
+++ b/platform/ext/target/nordic_nrf/common/nrf91/nrfx_config_nrf91.h
@@ -36,6 +36,17 @@
 #error "This file should not be included directly. Include nrfx_config.h instead."
 #endif
 
+/*
+ * The MDK for nRF9120 used in the nRF9161 target doesn't define the Secure FPU
+ * as it doesn't exist, but for other platforms like the 9160 it has a dummy
+ * define.
+ * Therefore we define it here manually until it is fixed in the MDK.
+ * See: NCSDK-23046
+ */
+#ifdef NRF9120_XXAA
+#define NRF_FPU_S    1
+#endif
+
 #define NRF_CLOCK        NRF_PERIPH(NRF_CLOCK)
 #define NRF_DPPIC        NRF_PERIPH(NRF_DPPIC)
 #define NRF_EGU0         NRF_PERIPH(NRF_EGU0)


### PR DESCRIPTION
The MDK for nRF9120 used in the nRF9161 target doesn't define the Secure FPU as it doesn't exist, but for other platforms like the 9160 it has a dummy define, with an UNUSED field in the type.
The long plan is to get this fixed in the MDK but until then, to make the nrfxlib 3.1.0 update possible this tempfix is applied.

 Ref: NCSDK-23046


Change-Id: I44042ee9aada99c59a5930440306bb6c40ae4880