### PR TITLE
[nrf noup]: platform: ext: target: nordic_nrf: add atomic macros to glue

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
+++ b/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
@@ -33,6 +33,7 @@
 #define NRFX_GLUE_H__
 
 #include <assert.h>
+#include <zephyr/sys/atomic.h>
 
 #include <soc/nrfx_coredep.h>
 
@@ -154,7 +155,7 @@ void nrfx_critical_section_exit(void);
 //------------------------------------------------------------------------------
 
 /** @brief Atomic 32-bit unsigned type. */
-#define nrfx_atomic_t
+#define nrfx_atomic_t  atomic_t
 
 /**
  * @brief Macro for storing a value to an atomic object and returning its previous value.
@@ -164,7 +165,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_STORE(p_data, value)
+#define NRFX_ATOMIC_FETCH_STORE(p_data, value)  atomic_set(p_data, value)
 
 /**
  * @brief Macro for running a bitwise OR operation on an atomic object and returning its previous value.
@@ -174,7 +175,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_OR(p_data, value)
+#define NRFX_ATOMIC_FETCH_OR(p_data, value)  atomic_or(p_data, value)
 
 /**
  * @brief Macro for running a bitwise AND operation on an atomic object
@@ -185,7 +186,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_AND(p_data, value)
+#define NRFX_ATOMIC_FETCH_AND(p_data, value)  atomic_and(p_data, value)
 
 /**
  * @brief Macro for running a bitwise XOR operation on an atomic object
@@ -196,7 +197,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_XOR(p_data, value)
+#define NRFX_ATOMIC_FETCH_XOR(p_data, value)  atomic_xor(p_data, value)
 
 /**
  * @brief Macro for running an addition operation on an atomic object
@@ -207,7 +208,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_ADD(p_data, value)
+#define NRFX_ATOMIC_FETCH_ADD(p_data, value)  atomic_add(p_data, value)
 
 /**
  * @brief Macro for running a subtraction operation on an atomic object
@@ -218,7 +219,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_SUB(p_data, value)
+#define NRFX_ATOMIC_FETCH_SUB(p_data, value)  atomic_sub(p_data, value)
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
nrfx_uarte driver requires missing atomic macros:
 - nrfx_atomic_t
 - NRFX_ATOMIC_FETCH...