### PR TITLE
[nrf fromlist] platform: nordic_nrf: Fix assert in initialization

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -744,10 +744,13 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
     /* Peripheral configuration */
 
     /* The following peripherals share ID:
-     * - FPU
+     * - FPU (FPU cannot be configured in NRF91 series, it's always NS)
      * - DCNF (On 53, but not 91)
      */
+#ifndef NRF91_SERIES
     spu_peripheral_config_non_secure((uint32_t)NRF_FPU, false);
+#endif
+
     /* The following peripherals share ID:
      * - REGULATORS
      * - OSCILLATORS


### PR DESCRIPTION
This fixes an erroneous attempt to configure the FPU peripheral in NRF91 series. The FPU is not configurable in NRF91 series and it is always non-secure. This caused a failed assertion in the initialzation since the FPU present field is not set for the SPU configuration.

This change configures the FPU only in NRF53 series devices which have a configurable FPU.

Ref: NCSDK-23619


Change-Id: Ia00e0e620ab51850e6ee8b382e5d03a245b6db0c