### PR TITLE
[nrf fromlist] platform: nordic_nrf: Set UART pins using pinctrl method

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
+++ b/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
@@ -21,6 +21,9 @@
 #include <RTE_Device.h>
 #include <nrfx_uarte.h>
 #include <string.h>
+#include <stdint.h>
+#include <nrf-pinctrl.h>
+#include <array.h>
 
 #if !(DOMAIN_NS == 1U) && defined(CONFIG_TFM_LOG_SHARE_UART)
 #define SPU_CONFIGURE_UART
@@ -35,6 +38,43 @@
 
 #if RTE_USART0 || RTE_USART1 || RTE_USART2 || RTE_USART3
 
+#define PSEL_DISCONNECTED 0xFFFFFFFFUL
+
+#define UART_CONFIG_INITIALIZER()                                              \
+{                                                                              \
+    .txd_pin  = PSEL_DISCONNECTED,                                             \
+    .rxd_pin  = PSEL_DISCONNECTED,                                             \
+    .rts_pin  = PSEL_DISCONNECTED,                                             \
+    .cts_pin  = PSEL_DISCONNECTED,                                             \
+    .baudrate = NRF_UARTE_BAUDRATE_115200,                                     \
+    .interrupt_priority = NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY,              \
+    .config  = {                                                               \
+        .hwfc   = NRF_UARTE_HWFC_DISABLED,                                     \
+        .parity = NRF_UARTE_PARITY_EXCLUDED,                                   \
+        .stop   = NRF_UARTE_STOP_ONE,                                          \
+    },                                                                         \
+}
+
+void uart_config_set_uart_pins(nrfx_uarte_config_t *uart_config,
+                               const uint32_t uart_pins[],
+                               size_t uart_pins_count)
+{
+    for (size_t i = 0; i < uart_pins_count; i++) {
+        uint32_t psel = NRF_GET_PIN(uart_pins[i]);
+
+        if (psel == NRF_PIN_DISCONNECTED) {
+            psel = PSEL_DISCONNECTED;
+        }
+
+        switch (NRF_GET_FUN(uart_pins[i])) {
+        case NRF_FUN_UART_TX:  uart_config->txd_pin = psel; break;
+        case NRF_FUN_UART_RX:  uart_config->rxd_pin = psel; break;
+        case NRF_FUN_UART_RTS: uart_config->rts_pin = psel; break;
+        case NRF_FUN_UART_CTS: uart_config->cts_pin = psel; break;
+        }
+    }
+}
+
 static const ARM_DRIVER_VERSION DriverVersion = {
     ARM_USART_API_VERSION,
     ARM_USART_DRV_VERSION
@@ -46,7 +86,8 @@ static const ARM_USART_CAPABILITIES DriverCapabilities = {
 
 typedef struct {
     const nrfx_uarte_t   uarte;
-    const nrfx_uarte_config_t *initial_config;
+    const uint32_t      *uart_pins;
+    size_t               uart_pins_count;
     size_t               tx_count;
     size_t               rx_count;
     nrf_uarte_config_t   hal_cfg;
@@ -74,8 +115,14 @@ static int32_t ARM_USARTx_Initialize(ARM_USART_SignalEvent_t cb_event,
     NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET((uint32_t)uart_resources->uarte.p_reg));
 #endif
 
+    nrfx_uarte_config_t uart_config = UART_CONFIG_INITIALIZER();
+
+    uart_config_set_uart_pins(&uart_config,
+                              uart_resources->uart_pins,
+                              uart_resources->uart_pins_count);
+
     nrfx_err_t err_code = nrfx_uarte_init(&uart_resources->uarte,
-                                          uart_resources->initial_config,
+                                          &uart_config,
                                           NULL);
     if (err_code != NRFX_SUCCESS) {
         return ARM_DRIVER_ERROR_BUSY;
@@ -83,8 +130,8 @@ static int32_t ARM_USARTx_Initialize(ARM_USART_SignalEvent_t cb_event,
 
     uart_resources->tx_count = 0;
     uart_resources->rx_count = 0;
-    uart_resources->hal_cfg  = uart_resources->initial_config->config;
-    uart_resources->baudrate = uart_resources->initial_config->baudrate;
+    uart_resources->hal_cfg  = uart_config.config;
+    uart_resources->baudrate = uart_config.baudrate;
 
     uart_resources->initialized = true;
     return ARM_DRIVER_OK;
@@ -315,22 +362,11 @@ static ARM_USART_MODEM_STATUS ARM_USART_GetModemStatus(void)
 }
 
 #define DRIVER_USART(idx)                                                 \
-    static nrfx_uarte_config_t UART##idx##_initial_config = {             \
-        .txd_pin  = RTE_USART##idx##_TXD_PIN,                             \
-        .rxd_pin  = RTE_USART##idx##_RXD_PIN,                             \
-        .rts_pin  = RTE_USART##idx##_RTS_PIN,                             \
-        .cts_pin  = RTE_USART##idx##_CTS_PIN,                             \
-        .baudrate = NRF_UARTE_BAUDRATE_115200,                            \
-        .interrupt_priority = NRFX_UARTE_DEFAULT_CONFIG_IRQ_PRIORITY,     \
-        .config  = {                                                     \
-            .hwfc   = RTE_USART##idx##_HWFC,                            \
-            .parity = NRF_UARTE_PARITY_EXCLUDED,                          \
-            .stop   = NRF_UARTE_STOP_ONE,                                 \
-        },                                                                \
-    };                                                                    \
+    static const uint32_t UART##idx##_pins[] = RTE_USART##idx##_PINS;     \
     static UARTx_Resources UART##idx##_Resources = {                      \
         .uarte = NRFX_UARTE_INSTANCE(idx),                                \
-        .initial_config = &UART##idx##_initial_config,                    \
+        .uart_pins = UART##idx##_pins,                                    \
+        .uart_pins_count = ARRAY_SIZE(UART##idx##_pins)                   \
     };                                                                    \
     static int32_t ARM_USART##idx##_Initialize(                           \
                                         ARM_USART_SignalEvent_t cb_event) \

--- a/platform/ext/target/nordic_nrf/common/core/common/nrf-pinctrl.h
+++ b/platform/ext/target/nordic_nrf/common/core/common/nrf-pinctrl.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef NRF_INCLUDE_NRF_PINCTRL_H
+#define NRF_INCLUDE_NRF_PINCTRL_H
+
+/*
+ * The whole nRF pin configuration information is encoded in a 32-bit bitfield
+ * organized as follows:
+ *
+ * - 31..16: Pin function.
+ * - 15:     Reserved.
+ * - 14:     Pin inversion mode.
+ * - 13:     Pin low power mode.
+ * - 12..9:  Pin output drive configuration.
+ * - 8..7:   Pin pull configuration.
+ * - 6..0:   Pin number (combination of port and pin).
+ */
+
+/**
+ * @name nRF pin configuration bit field positions and masks.
+ * @{
+ */
+
+/** Position of the function field. */
+#define NRF_FUN_POS 16U
+/** Mask for the function field. */
+#define NRF_FUN_MSK 0xFFFFU
+/** Position of the invert field. */
+#define NRF_INVERT_POS 14U
+/** Mask for the invert field. */
+#define NRF_INVERT_MSK 0x1U
+/** Position of the low power field. */
+#define NRF_LP_POS 13U
+/** Mask for the low power field. */
+#define NRF_LP_MSK 0x1U
+/** Position of the drive configuration field. */
+#define NRF_DRIVE_POS 9U
+/** Mask for the drive configuration field. */
+#define NRF_DRIVE_MSK 0xFU
+/** Position of the pull configuration field. */
+#define NRF_PULL_POS 7U
+/** Mask for the pull configuration field. */
+#define NRF_PULL_MSK 0x3U
+/** Position of the pin field. */
+#define NRF_PIN_POS 0U
+/** Mask for the pin field. */
+#define NRF_PIN_MSK 0x7FU
+
+/** @} */
+
+/**
+ * @name nRF pinctrl pin functions.
+ * @{
+ */
+
+/** UART TX */
+#define NRF_FUN_UART_TX 0U
+/** UART RX */
+#define NRF_FUN_UART_RX 1U
+/** UART RTS */
+#define NRF_FUN_UART_RTS 2U
+/** UART CTS */
+#define NRF_FUN_UART_CTS 3U
+
+/** Indicates that a pin is disconnected */
+#define NRF_PIN_DISCONNECTED NRF_PIN_MSK
+
+/** @} */
+
+/**
+ * @brief Utility macro to build nRF psels property entry.
+ *
+ * @param fun Pin function configuration (see NRF_FUNC_{name} macros).
+ * @param port Port (0 or 1).
+ * @param pin Pin (0..31).
+ */
+#define NRF_PSEL(fun, port, pin)						       \
+	((((((port) * 32U) + (pin)) & NRF_PIN_MSK) << NRF_PIN_POS) |		       \
+	 ((NRF_FUN_ ## fun & NRF_FUN_MSK) << NRF_FUN_POS))
+
+/**
+ * @brief Utility macro to build nRF psels property entry when a pin is disconnected.
+ *
+ * This can be useful in situations where code running before Zephyr, e.g. a bootloader
+ * configures pins that later needs to be disconnected.
+ *
+ * @param fun Pin function configuration (see NRF_FUN_{name} macros).
+ */
+#define NRF_PSEL_DISCONNECTED(fun)						       \
+	(NRF_PIN_DISCONNECTED |							       \
+	 ((NRF_FUN_ ## fun & NRF_FUN_MSK) << NRF_FUN_POS))
+
+/**
+ * @brief Utility macro to obtain pin function.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_FUN(pincfg) (((pincfg) >> NRF_FUN_POS) & NRF_FUN_MSK)
+
+
+/**
+ * @brief Utility macro to obtain port and pin combination.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_PIN(pincfg) (((pincfg) >> NRF_PIN_POS) & NRF_PIN_MSK)
+
+#endif /* NRF_INCLUDE_NRF_PINCTRL_H */

--- a/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/RTE_Device.h
@@ -15,82 +15,32 @@
  * limitations under the License.
  */
 
-//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
-
 #ifndef __RTE_DEVICE_H
 #define __RTE_DEVICE_H
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
-// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
-#define   RTE_USART0                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART0_TXD_PIN            20
-//     <o> RXD
-#define   RTE_USART0_RXD_PIN            22
-//     <o> RTS
-#define   RTE_USART0_RTS_PIN            19
-//     <o> CTS
-#define   RTE_USART0_CTS_PIN            21
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+#include <nrf-pinctrl.h>
 
-#define   RTE_USART0_HWFC               NRF_UARTE_HWFC_DISABLED
+#define RTE_USART0 1
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
-// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
-#define   RTE_USART1                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART1_TXD_PIN            25
-//     <o> RXD
-#define   RTE_USART1_RXD_PIN            26
-//     <o> RTS
-#define   RTE_USART1_RTS_PIN            5
-//     <o> CTS
-#define   RTE_USART1_CTS_PIN            6
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+#define RTE_USART0_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0, 20), \
+        NRF_PSEL(UART_RX,  0, 22), \
+        NRF_PSEL(UART_RTS, 0, 19), \
+        NRF_PSEL(UART_CTS, 0, 21), \
+}
 
-#define   RTE_USART1_HWFC               NRF_UARTE_HWFC_DISABLED
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
-// <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
-#define   RTE_USART2                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART2_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART2_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART2_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART2_CTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+#define RTE_USART1 1
 
-#define   RTE_USART2_HWFC               NRF_UARTE_HWFC_DISABLED
+#define RTE_USART1_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0, 25), \
+        NRF_PSEL(UART_RX,  0, 26), \
+        NRF_PSEL(UART_RTS, 0,  5), \
+        NRF_PSEL(UART_CTS, 0,  6), \
+}
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
-// <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
-#define   RTE_USART3                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART3_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART3_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
-
-#define   RTE_USART3_HWFC               NRF_UARTE_HWFC_DISABLED
-
-// <e> FLASH (Flash Memory) [Driver_FLASH0]
-// <i> Configuration settings for Driver_FLASH0 in component ::Drivers:FLASH
-#define   RTE_FLASH0                    1
-// </e> FLASH (Flash Memory) [Driver_FLASH0]
+#define RTE_FLASH0 1
 
 #endif  /* __RTE_DEVICE_H */

--- a/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/RTE_Device.h
@@ -15,81 +15,32 @@
  * limitations under the License.
  */
 
-//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
-
 #ifndef __RTE_DEVICE_H
 #define __RTE_DEVICE_H
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
-// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
-#define   RTE_USART0                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART0_TXD_PIN            29
-//     <o> RXD
-#define   RTE_USART0_RXD_PIN            28
-//     <o> RTS
-#define   RTE_USART0_RTS_PIN            27
-//     <o> CTS
-#define   RTE_USART0_CTS_PIN            26
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+#include <nrf-pinctrl.h>
 
-#define   RTE_USART0_HWFC               NRF_UARTE_HWFC_DISABLED
+#define RTE_USART0 1
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
-// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
-#define   RTE_USART1                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART1_TXD_PIN            1
-//     <o> RXD
-#define   RTE_USART1_RXD_PIN            0
-//     <o> RTS
-#define   RTE_USART1_RTS_PIN            14
-//     <o> CTS
-#define   RTE_USART1_CTS_PIN            15
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+#define RTE_USART0_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0, 29), \
+        NRF_PSEL(UART_RX,  0, 28), \
+        NRF_PSEL(UART_RTS, 0, 27), \
+        NRF_PSEL(UART_CTS, 0, 26), \
+}
 
-#define   RTE_USART1_HWFC               NRF_UARTE_HWFC_DISABLED
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
-// <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
-#define   RTE_USART2                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART2_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART2_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART2_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART2_CTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+#define RTE_USART1 1
 
-#define   RTE_USART2_HWFC               NRF_UARTE_HWFC_DISABLED
+#define RTE_USART1_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0,  1), \
+        NRF_PSEL(UART_RX,  0,  0), \
+        NRF_PSEL(UART_RTS, 0, 14), \
+        NRF_PSEL(UART_CTS, 0, 15), \
+}
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
-// <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
-#define   RTE_USART3                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART3_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART3_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
-
-#define   RTE_USART3_HWFC               NRF_UARTE_HWFC_DISABLED
-// <e> FLASH (Flash Memory) [Driver_FLASH0]
-// <i> Configuration settings for Driver_FLASH0 in component ::Drivers:FLASH
-#define   RTE_FLASH0                    1
-// </e> FLASH (Flash Memory) [Driver_FLASH0]
+#define RTE_FLASH0 1
 
 #endif  /* __RTE_DEVICE_H */

--- a/platform/ext/target/nordic_nrf/nrf9161dk_nrf9161/RTE_Device.h
+++ b/platform/ext/target/nordic_nrf/nrf9161dk_nrf9161/RTE_Device.h
@@ -4,74 +4,32 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-5-Clause
  */
 
-//-------- <<< Use Configuration Wizard in Context Menu >>> --------------------
-
 #ifndef __RTE_DEVICE_H
 #define __RTE_DEVICE_H
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
-// <i> Configuration settings for Driver_USART0 in component ::Drivers:USART
-#define   RTE_USART0                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART0_TXD_PIN            27
-//     <o> RXD
-#define   RTE_USART0_RXD_PIN            26
-//     <o> RTS
-#define   RTE_USART0_RTS_PIN            14
-//     <o> CTS
-#define   RTE_USART0_CTS_PIN            15
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART0]
+#include <nrf-pinctrl.h>
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
-// <i> Configuration settings for Driver_USART1 in component ::Drivers:USART
-#define   RTE_USART1                    1
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART1_TXD_PIN            29
-//     <o> RXD
-#define   RTE_USART1_RXD_PIN            28
-//     <o> RTS
-#define   RTE_USART1_RTS_PIN            16
-//     <o> CTS
-#define   RTE_USART1_CTS_PIN            17
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART1]
+#define RTE_USART0 1
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
-// <i> Configuration settings for Driver_USART2 in component ::Drivers:USART
-#define   RTE_USART2                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART2_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART2_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART2_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART2_CTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART2]
+#define RTE_USART0_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0, 27), \
+        NRF_PSEL(UART_RX,  0, 26), \
+        NRF_PSEL(UART_RTS, 0, 14), \
+        NRF_PSEL(UART_CTS, 0, 15), \
+}
 
-// <e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
-// <i> Configuration settings for Driver_USART3 in component ::Drivers:USART
-#define   RTE_USART3                    0
-//   <h> Pin Selection (0xFFFFFFFF means Disconnected)
-//     <o> TXD
-#define   RTE_USART3_TXD_PIN            0xFFFFFFFF
-//     <o> RXD
-#define   RTE_USART3_RXD_PIN            0xFFFFFFFF
-//     <o> RTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//     <o> CTS
-#define   RTE_USART3_RTS_PIN            0xFFFFFFFF
-//   </h> Pin Configuration
-// </e> USART (Universal synchronous - asynchronous receiver transmitter) [Driver_USART3]
 
-// <e> FLASH (Flash Memory) [Driver_FLASH0]
-// <i> Configuration settings for Driver_FLASH0 in component ::Drivers:FLASH
-#define   RTE_FLASH0                    1
-// </e> FLASH (Flash Memory) [Driver_FLASH0]
+#define RTE_USART1 1
+
+#define RTE_USART1_PINS            \
+{                                  \
+        NRF_PSEL(UART_TX,  0, 29), \
+        NRF_PSEL(UART_RX,  0, 28), \
+        NRF_PSEL(UART_RTS, 0, 16), \
+        NRF_PSEL(UART_CTS, 0, 18), \
+}
+
+#define RTE_FLASH0 1
 
 #endif  /* __RTE_DEVICE_H */


### PR DESCRIPTION
Use the pinctrl method to define the UART pins for the nordic platform UART driver.
This makes it easier to assign the UART pins from devicetree information which is used in out-of-tree board support.

Upstream PR:
https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/23662

Change-Id: I8f18b730d705214670438b85c58032c6f32fff1c