### PR TITLE
[nrf fromlist] platform: nordic_nrf: add builtin atomic macros to glue

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
+++ b/platform/ext/target/nordic_nrf/common/core/common/nrfx_glue.h
@@ -154,7 +154,7 @@ void nrfx_critical_section_exit(void);
 //------------------------------------------------------------------------------
 
 /** @brief Atomic 32-bit unsigned type. */
-#define nrfx_atomic_t
+#define nrfx_atomic_t  long
 
 /**
  * @brief Macro for storing a value to an atomic object and returning its previous value.
@@ -164,7 +164,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_STORE(p_data, value)
+#define NRFX_ATOMIC_FETCH_STORE(p_data, value)  __atomic_exchange_n(p_data, value, __ATOMIC_SEQ_CST)
 
 /**
  * @brief Macro for running a bitwise OR operation on an atomic object and returning its previous value.
@@ -174,7 +174,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_OR(p_data, value)
+#define NRFX_ATOMIC_FETCH_OR(p_data, value)  __atomic_fetch_or(p_data, value, __ATOMIC_SEQ_CST)
 
 /**
  * @brief Macro for running a bitwise AND operation on an atomic object
@@ -185,7 +185,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_AND(p_data, value)
+#define NRFX_ATOMIC_FETCH_AND(p_data, value)  __atomic_fetch_and(p_data, value, __ATOMIC_SEQ_CST)
 
 /**
  * @brief Macro for running a bitwise XOR operation on an atomic object
@@ -196,7 +196,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_XOR(p_data, value)
+#define NRFX_ATOMIC_FETCH_XOR(p_data, value)  __atomic_fetch_xor(p_data, value, __ATOMIC_SEQ_CST)
 
 /**
  * @brief Macro for running an addition operation on an atomic object
@@ -207,7 +207,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_ADD(p_data, value)
+#define NRFX_ATOMIC_FETCH_ADD(p_data, value)  __atomic_fetch_add(p_data, value, __ATOMIC_SEQ_CST)
 
 /**
  * @brief Macro for running a subtraction operation on an atomic object
@@ -218,7 +218,7 @@ void nrfx_critical_section_exit(void);
  *
  * @return Previous value of the atomic object.
  */
-#define NRFX_ATOMIC_FETCH_SUB(p_data, value)
+#define NRFX_ATOMIC_FETCH_SUB(p_data, value)  __atomic_fetch_sub(p_data, value, __ATOMIC_SEQ_CST)
 
 //------------------------------------------------------------------------------
 


### PR DESCRIPTION
Updated nrfx_uarte driver requires missing atomic macros:
- nrfx_atomic_t
- NRFX_ATOMIC_FETCH_*