### PR TITLE
[nrf fromtree] platform: nordic_nrf: Fix nrf9160 non-secure periphera…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -826,8 +826,14 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
     spu_peripheral_config_non_secure((uint32_t)NRF_PWM1, false);
     spu_peripheral_config_non_secure((uint32_t)NRF_PWM2, false);
     spu_peripheral_config_non_secure((uint32_t)NRF_PWM3, false);
+#ifdef NRF_PDM
+    spu_peripheral_config_non_secure((uint32_t)NRF_PDM, false);
+#endif
 #ifdef NRF_PDM0
     spu_peripheral_config_non_secure((uint32_t)NRF_PDM0, false);
+#endif
+#ifdef NRF_I2S
+    spu_peripheral_config_non_secure((uint32_t)NRF_I2S, false);
 #endif
 #ifdef NRF_I2S0
     spu_peripheral_config_non_secure((uint32_t)NRF_I2S0, false);


### PR DESCRIPTION
…l regression

Fix regression since target_cfg.c was refactored to a common file for nrf91 and nrf53.
The I2S and PDM peripheral are not configured as non-secure peripherals.

Change-Id: Ibc2c0caa0694458f2b0071976a7494a0d23f529b

(cherry picked from commit 3bd6fb8250fbbf5f92733e355d9abcfde253b532) (cherry picked from commit f2a462080edc42818003d052c57d777954220145)