### PR TITLE
[nrf noup] platform: nordic_nrf: Fix NS build with floating point ena…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -42,7 +42,16 @@ if(NS)
     )
     target_link_libraries(CMSIS_5_tfm_ns
         INTERFACE
-            CMSIS_5_RTX_V8MMN
+            $<$<OR:$<BOOL:${CONFIG_TFM_ENABLE_FP}>,$<BOOL:${CONFIG_TFM_ENABLE_MVE_FP}>>:CMSIS_5_RTX_V8MMFN>
+            $<$<NOT:$<OR:$<BOOL:${CONFIG_TFM_ENABLE_FP}>,$<BOOL:${CONFIG_TFM_ENABLE_MVE_FP}>>>:CMSIS_5_RTX_V8MMN>
+    )
+    target_compile_options(tfm_ns
+        PUBLIC
+            ${COMPILER_CP_FLAG}
+    )
+    target_link_options(tfm_ns
+        PUBLIC
+            ${LINKER_CP_OPTION}
     )
     target_sources(tfm_ns
         PRIVATE


### PR DESCRIPTION
…bled

Fix TF-M building of the NS application with floating point enabled. This is needed in order to run the TF-M regression tests.

NOUP:
This does not have an upstream PR as this problem does not exits in the main branch after the TF-M split NS build feature merge. This commit should therefore just be reverted on next TF-M sync.