### PR TITLE
Revert "[nrf noup] platform: crypto: Check if for config instead of s…

### DIFF
--- a/platform/include/tfm_plat_crypto_keys.h
+++ b/platform/include/tfm_plat_crypto_keys.h
@@ -8,19 +8,12 @@
 #ifndef __TFM_PLAT_CRYPTO_KEYS_H__
 #define __TFM_PLAT_CRYPTO_KEYS_H__
 
-
-#include <stddef.h>
 #include <stdint.h>
 #include "psa/crypto.h"
 #include "tfm_plat_defs.h"
-#include "tfm_mbedcrypto_include.h"
 
 #ifdef __cplusplus
 extern "C" {
-#endif
-
-#ifndef MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER
-#error "MBEDTLS_PSA_CRYPTO_KEY_ID_ENCODES_OWNER must be selected in Mbed TLS config file"
 #endif
 
 /**


### PR DESCRIPTION
…etting it"

This reverts commit 6af37f1a59e7c94e4054fbd1ef0f8505ddc899ba.

This noup in tf-m is no longer needed as
crypto_library.c
is doing the same ifdef #error.

Change-Id: I2dbcc4b44581201513ce3d5f834ee390a4177eb8