### PR TITLE
[nrf noup] Remove check for P256M

### DIFF
--- a/secure_fw/partitions/crypto/CMakeLists.txt
+++ b/secure_fw/partitions/crypto/CMakeLists.txt
@@ -138,20 +138,8 @@ set(MBEDTLS_TARGET_PREFIX crypto_service_)
 #set(MBEDTLS_PSA_CRYPTO_CONFIG_FILE "${TFM_MBEDCRYPTO_PSA_CRYPTO_CONFIG_PATH}")
 #set(MBEDTLS_CONFIG_FILE "${TFM_MBEDCRYPTO_CONFIG_PATH}")
 
-# Check if the p256m driver is enabled in the config file, as that will require a
-# dedicated target to be linked in. Note that 0 means SUCCESS here, 1 means FAILURE
-set(MBEDTLS_P256M_NOT_FOUND 1)
-execute_process(COMMAND
-    ${Python3_EXECUTABLE}
-    ${MBEDCRYPTO_PATH}/scripts/config.py -f "${TFM_MBEDCRYPTO_CONFIG_PATH}" get MBEDTLS_PSA_P256M_DRIVER_ENABLED
-    RESULT_VARIABLE MBEDTLS_P256M_NOT_FOUND)
-
-if (${MBEDTLS_P256M_NOT_FOUND} EQUAL 0)
-    message(STATUS "[Crypto service] Using P256M software driver in PSA Crypto backend")
-    set(MBEDTLS_P256M_ENABLED true)
-else()
-    set(MBEDTLS_P256M_ENABLED false)
-endif()
+# We use hardware acceleration or ocrypto so disable the P256M module by default
+set(MBEDTLS_P256M_ENABLED false)
 
 # Mbedcrypto is quite a large lib, and it uses too much memory for it to be
 # reasonable to build it in debug info. As a compromise, if `debug` build type


### PR DESCRIPTION
TF-M checks if P256M is available during build time using MBEDCRYPTO_PATH which is set to the TF-M repo to use custom mbed TLS cmake configurations, but this means the script can not be found. But as mbed TLS software crypto is not used anyway we can hardcode P256M to be disabled.


Change-Id: I94fde1f41e3493e840823cae284256176a364863