### PR TITLE
Crypto: Add missing key derivation APIs in the interface

### DIFF
--- a/interface/include/tfm_crypto_defs.h
+++ b/interface/include/tfm_crypto_defs.h
@@ -47,7 +47,6 @@ struct tfm_crypto_pack_iovec {
     uint32_t op_handle;      /*!< Frontend context handle associated to a
                               *   multipart operation
                               */
-    size_t capacity;         /*!< Key derivation capacity */
     size_t ad_length;        /*!< Additional Data length for multipart AEAD */
     size_t plaintext_length; /*!< Plaintext length for multipart AEAD */
 
@@ -59,6 +58,10 @@ struct tfm_crypto_pack_iovec {
                               */
     uint16_t step;           /*!< Key derivation step */
     psa_pake_role_t role;    /*!< PAKE role */
+    union {
+        size_t capacity;     /*!< Key derivation capacity */
+        uint64_t value;      /*!< Key derivation integer for update*/
+    };
 };
 
 /**
@@ -155,6 +158,7 @@ enum tfm_crypto_group_id {
     X(TFM_CRYPTO_KEY_DERIVATION_SET_CAPACITY)      \
     X(TFM_CRYPTO_KEY_DERIVATION_INPUT_BYTES)       \
     X(TFM_CRYPTO_KEY_DERIVATION_INPUT_KEY)         \
+    X(TFM_CRYPTO_KEY_DERIVATION_INPUT_INTEGER)     \
     X(TFM_CRYPTO_KEY_DERIVATION_KEY_AGREEMENT)     \
     X(TFM_CRYPTO_KEY_DERIVATION_OUTPUT_BYTES)      \
     X(TFM_CRYPTO_KEY_DERIVATION_OUTPUT_KEY)        \

--- a/interface/src/tfm_crypto_api.c
+++ b/interface/src/tfm_crypto_api.c
@@ -1657,7 +1657,6 @@ TFM_CRYPTO_API(psa_status_t, psa_key_derivation_output_key)(
     return API_DISPATCH(in_vec, out_vec);
 }
 
-
 TFM_CRYPTO_API(psa_status_t, psa_pake_setup)
 (psa_pake_operation_t *operation, psa_key_id_t password_key,
  const psa_pake_cipher_suite_t *cipher_suite) {
@@ -1811,4 +1810,40 @@ TFM_CRYPTO_API(psa_status_t, psa_pake_abort)(psa_pake_operation_t *operation) {
   };
 
   return API_DISPATCH(in_vec, out_vec);
+}
+
+TFM_CRYPTO_API(psa_status_t, psa_key_derivation_input_integer)(
+                                      psa_key_derivation_operation_t *operation,
+                                      psa_key_derivation_step_t step,
+                                      uint64_t value)
+{
+    struct tfm_crypto_pack_iovec iov = {
+        .function_id = TFM_CRYPTO_KEY_DERIVATION_INPUT_INTEGER_SID,
+        .step = step,
+        .value = value,
+        .op_handle = operation->handle,
+    };
+
+    psa_invec in_vec[] = {
+        {.base = &iov, .len = sizeof(struct tfm_crypto_pack_iovec)},
+    };
+
+    return API_DISPATCH_NO_OUTVEC(in_vec);
+}
+
+TFM_CRYPTO_API(psa_status_t, psa_key_derivation_verify_bytes)(
+                                      psa_key_derivation_operation_t *operation,
+                                      const uint8_t *expected_output,
+                                      size_t output_length)
+{
+    /* To be implemented when the PSA backend supports it */
+    return PSA_ERROR_NOT_SUPPORTED;
+}
+
+TFM_CRYPTO_API(psa_status_t, psa_key_derivation_verify_key)(
+                                      psa_key_derivation_operation_t *operation,
+                                      psa_key_id_t expected)
+{
+    /* To be implemented when the PSA backend supports it */
+    return PSA_ERROR_NOT_SUPPORTED;
 }

--- a/secure_fw/partitions/crypto/crypto_key_derivation.c
+++ b/secure_fw/partitions/crypto/crypto_key_derivation.c
@@ -94,6 +94,10 @@ psa_status_t tfm_crypto_key_derivation_interface(psa_invec in_vec[],
         return psa_key_derivation_input_bytes(operation, iov->step, data,
                                               data_length);
     }
+    case TFM_CRYPTO_KEY_DERIVATION_INPUT_INTEGER_SID:
+    {
+        return psa_key_derivation_input_integer(operation, iov->step, iov->value);
+    }
     case TFM_CRYPTO_KEY_DERIVATION_OUTPUT_BYTES_SID:
     {
         uint8_t *output = out_vec[0].base;

--- a/secure_fw/partitions/crypto/crypto_spe.h
+++ b/secure_fw/partitions/crypto/crypto_spe.h
@@ -30,8 +30,14 @@
         PSA_FUNCTION_NAME(psa_key_derivation_set_capacity)
 #define psa_key_derivation_input_bytes \
         PSA_FUNCTION_NAME(psa_key_derivation_input_bytes)
+#define psa_key_derivation_input_integer \
+        PSA_FUNCTION_NAME(psa_key_derivation_input_integer)
+#define psa_key_derivation_verify_key \
+        PSA_FUNCTION_NAME(psa_key_derivation_verify_key)
 #define psa_key_derivation_output_bytes \
         PSA_FUNCTION_NAME(psa_key_derivation_output_bytes)
+#define psa_key_derivation_verify_bytes \
+        PSA_FUNCTION_NAME(psa_key_derivation_verify_bytes)
 #define psa_key_derivation_input_key \
         PSA_FUNCTION_NAME(psa_key_derivation_input_key)
 #define psa_key_derivation_output_key \


### PR DESCRIPTION
Cherry pick from upstream TF-M to support psa_key_derivation_input_integer needed for pbkdf2.