### PR TITLE
[nrf noup] Support CMAC KDF and custom builtin solution

### DIFF
--- a/config/config_base.cmake
+++ b/config/config_base.cmake
@@ -124,6 +124,7 @@ set(BL2_TRAILER_SIZE                    0x000       CACHE STRING    "BL2 Trailer
 set(TFM_PARTITION_PROTECTED_STORAGE     OFF         CACHE BOOL      "Enable Protected Storage partition")
 set(PS_ENCRYPTION                       ON          CACHE BOOL      "Enable encryption for Protected Storage partition")
 set(PS_CRYPTO_AEAD_ALG                  PSA_ALG_GCM CACHE STRING    "The AEAD algorithm to use for authenticated encryption in Protected Storage")
+set(PS_CRYPTO_KDF_ALG                   PSA_ALG_HKDF(PSA_ALG_SHA_256) CACHE STRING "KDF Algorithm to use for Protect Storage")
 
 set(TFM_PARTITION_INTERNAL_TRUSTED_STORAGE OFF      CACHE BOOL      "Enable Internal Trusted Storage partition")
 set(ITS_ENCRYPTION                   OFF         CACHE BOOL      "Enable authenticated encryption of ITS files using platform specific APIs")

--- a/interface/include/psa/crypto_values.h
+++ b/interface/include/psa/crypto_values.h
@@ -2102,6 +2102,8 @@
 #define PSA_ALG_IS_PBKDF2_HMAC(alg)                                    \
     (((alg) & ~PSA_ALG_HASH_MASK) == PSA_ALG_PBKDF2_HMAC_BASE)
 
+#define PSA_ALG_SP800_108_COUNTER_CMAC          ((psa_algorithm_t) 0x08000800)
+
 /** The PBKDF2-AES-CMAC-PRF-128 password hashing / key stretching algorithm.
  *
  * PBKDF2 is defined by PKCS#5, republished as RFC 8018 (section 5.2).

--- a/secure_fw/partitions/crypto/crypto_library.c
+++ b/secure_fw/partitions/crypto/crypto_library.c
@@ -153,6 +153,7 @@ psa_status_t tfm_crypto_core_library_key_attributes_to_client(
     return PSA_SUCCESS;
 }
 
+#ifdef PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER
 /**
  * \brief This function is required by mbed TLS to enable support for
  *        platform builtin keys in the PSA Crypto core layer implemented
@@ -181,4 +182,5 @@ psa_status_t mbedtls_psa_platform_get_builtin_key(
 
     return PSA_ERROR_DOES_NOT_EXIST;
 }
+#endif
 /*!@}*/

--- a/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.c
+++ b/secure_fw/partitions/protected_storage/crypto/ps_crypto_interface.c
@@ -18,6 +18,10 @@
 #define PS_CRYPTO_AEAD_ALG PSA_ALG_GCM
 #endif
 
+#ifndef PS_CRYPTO_KDF_ALG
+#define PS_CRYPTO_KDF_ALG PSA_ALG_HKDF(PSA_ALG_SHA_256)
+#endif
+
 /* The PSA key type used by this implementation */
 #define PS_KEY_TYPE PSA_KEY_TYPE_AES
 /* The PSA key usage required by this implementation */
@@ -73,7 +77,7 @@ psa_status_t ps_crypto_setkey(const uint8_t *key_label, size_t key_label_len)
     psa_set_key_type(&attributes, PS_KEY_TYPE);
     psa_set_key_bits(&attributes, PSA_BYTES_TO_BITS(PS_KEY_LEN_BYTES));
 
-    status = psa_key_derivation_setup(&op, PSA_ALG_HKDF(PSA_ALG_SHA_256));
+    status = psa_key_derivation_setup(&op, PS_CRYPTO_KDF_ALG);
     if (status != PSA_SUCCESS) {
         return status;
     }
@@ -86,7 +90,8 @@ psa_status_t ps_crypto_setkey(const uint8_t *key_label, size_t key_label_len)
     }
 
     /* Supply the PS key label as an input to the key derivation */
-    status = psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_INFO,
+    status = psa_key_derivation_input_bytes(&op, PS_CRYPTO_KDF_ALG == PSA_ALG_SP800_108_COUNTER_CMAC ?
+                                            PSA_KEY_DERIVATION_INPUT_LABEL : PSA_KEY_DERIVATION_INPUT_INFO,
                                             key_label,
                                             key_label_len);
     if (status != PSA_SUCCESS) {


### PR DESCRIPTION
Allows custom key-loader to be used for the PSA core and allows configuring CMAC KDF usage for PS.