### PR TITLE
[noup] platform: nordic_nrf: Configure XL1/2 pin based on Kconfig

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -1230,8 +1230,11 @@ static const uint8_t target_peripherals[] = {
      * register fields are not accessible. That's why it is placed here.
      */
 #ifdef NRF53_SERIES
+#if defined(CONFIG_SOC_ENABLE_LFXO) && CONFIG_SOC_ENABLE_LFXO == 1
+/* CONFIG_SOC_ENABLE_LFXO doesn't exist for 54L15 target, might be changed in future */
     nrf_gpio_pin_control_select(PIN_XL1, NRF_GPIO_PIN_SEL_PERIPHERAL);
     nrf_gpio_pin_control_select(PIN_XL2, NRF_GPIO_PIN_SEL_PERIPHERAL);
+#endif /* CONFIG_SOC_ENABLE_LFXO */
 #endif
 #ifdef NRF54L15_ENGA_XXAA
     /* NRF54L has a different define */


### PR DESCRIPTION
For Secure only builds on 53 there exists the Kconfig CONFIG_SOC_ENABLE_LFXO to define if the XL1 and XL2 pin should be configured to used for the LFXO oscillator. TF-M should have the same behavior, to enable the possibility to use these pins for something else

noup as we don't have the NCS Kconfigs available in upstream TF-M, the change to pull them in was done in the noup commit: 1a178885e758b2a40a60a0dd419a29ed94236965

Ref: NCSDK-20678