### PR TITLE
[nrf noup] platform: nordic_nrf: 54L Use HUK library for EITS

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption_cracen.c
+++ b/platform/ext/target/nordic_nrf/common/core/tfm_hal_its_encryption_cracen.c
@@ -20,16 +20,15 @@
 #include "config_tfm.h"
 #include "platform/include/tfm_hal_its_encryption.h"
 #include "platform/include/tfm_hal_its.h"
-#include "psa/crypto.h"
-#include "tfm_crypto_defs.h"
+
+typedef uint64_t psa_drv_slot_number_t;
+#include <hw_unique_key.h>
+#include <cracen_psa.h>
+
 
 #define CHACHA20_KEY_SIZE 32
 #define TFM_ITS_AEAD_ALG PSA_ALG_CHACHA20_POLY1305
 
-#define ITS_ENCRYPTION_SUCCESS 0
-
-#define HUK_KMU_SLOT 2
-#define HUK_KMU_SIZE_BITS 128
 
 /* Global encryption counter which resets per boot. The counter ensures that
  * the nonce will not be identical for consecutive file writes during the same
@@ -78,9 +77,8 @@ enum tfm_hal_status_t tfm_hal_its_aead_generate_nonce(uint8_t *nonce,
         return TFM_HAL_ERROR_GENERIC;
     }
 
-    /* psa_generate_random is not using any key/its functions wo we can use it here*/
     if (g_enc_counter == 0) {
-        psa_status_t status = psa_generate_random(g_enc_nonce_seed, sizeof(g_enc_nonce_seed));
+        psa_status_t status =  cracen_get_random(NULL, g_enc_nonce_seed, sizeof(g_enc_nonce_seed));
         if (status != PSA_SUCCESS) {
             return TFM_HAL_ERROR_GENERIC;
         }
@@ -111,12 +109,8 @@ static bool ctx_is_valid(struct tfm_hal_its_auth_crypt_ctx *ctx)
     return !ret;
 }
 
-/*
- * The cracen driver code doesn't use any persistent keys so no calls to its
- * therefore the PSA API's can be used directly.
- */
 psa_status_t tfm_hal_its_get_aead(struct tfm_hal_its_auth_crypt_ctx *ctx,
-                                  uint8_t *plaintext,
+                                  const uint8_t *plaintext,
                                   const size_t plaintext_size,
                                   uint8_t *ciphertext,
                                   const size_t ciphertext_size,
@@ -125,9 +119,8 @@ psa_status_t tfm_hal_its_get_aead(struct tfm_hal_its_auth_crypt_ctx *ctx,
                                   bool encrypt)
 {
     psa_status_t status;
+    uint8_t key_out[CHACHA20_KEY_SIZE];
     psa_key_attributes_t attributes = PSA_KEY_ATTRIBUTES_INIT;
-    psa_key_derivation_operation_t op = PSA_KEY_DERIVATION_OPERATION_INIT;
-    psa_key_id_t key;
     size_t ciphertext_length;
     size_t tag_length = PSA_AEAD_TAG_LENGTH(PSA_KEY_TYPE_CHACHA20,
                                             PSA_BYTES_TO_BITS(CHACHA20_KEY_SIZE),
@@ -141,52 +134,27 @@ psa_status_t tfm_hal_its_get_aead(struct tfm_hal_its_auth_crypt_ctx *ctx,
         return TFM_HAL_ERROR_INVALID_INPUT;
     }
 
-    if (ciphertext_size < PSA_AEAD_ENCRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_CHACHA20,
-                                                       TFM_ITS_AEAD_ALG,
-                                                       plaintext_size)){
+    if (encrypt && (ciphertext_size < PSA_AEAD_ENCRYPT_OUTPUT_SIZE(PSA_KEY_TYPE_CHACHA20,
+                                                                   TFM_ITS_AEAD_ALG,
+                                                                   plaintext_size))){
         return TFM_HAL_ERROR_INVALID_INPUT;
     }
 
-    /* Set the key attributes for the key */
+
+    status = hw_unique_key_derive_key(HUK_KEYSLOT_MKEK, NULL, 0, ctx->deriv_label, ctx->deriv_label_size, key_out, sizeof(key_out));
+    if (status != HW_UNIQUE_KEY_SUCCESS) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
     psa_set_key_usage_flags(&attributes, (PSA_KEY_USAGE_ENCRYPT | PSA_KEY_USAGE_DECRYPT));
     psa_set_key_algorithm(&attributes, TFM_ITS_AEAD_ALG);
     psa_set_key_type(&attributes, PSA_KEY_TYPE_CHACHA20);
     psa_set_key_bits(&attributes, PSA_BYTES_TO_BITS(CHACHA20_KEY_SIZE));
 
-    status = psa_key_derivation_setup(&op, PSA_ALG_SP800_108_COUNTER_CMAC);
-    if (status != PSA_SUCCESS) {
-        return status;
-    }
-
-    /* Set up a key derivation operation with HUK  */
-    status = psa_key_derivation_input_key(&op, PSA_KEY_DERIVATION_INPUT_SECRET,
-                                          TFM_BUILTIN_KEY_ID_HUK);
-    if (status != PSA_SUCCESS) {
-        goto err_release_op;
-    }
-
-    /* Supply the PS key label as an input to the key derivation */
-    status = psa_key_derivation_input_bytes(&op, PSA_KEY_DERIVATION_INPUT_LABEL,
-                                            ctx->deriv_label,
-                                            ctx->deriv_label_size);
-    if (status != PSA_SUCCESS) {
-        goto err_release_op;
-    }
-
-    /* Create the storage key from the key derivation operation */
-    status = psa_key_derivation_output_key(&attributes, &op, &key);
-    if (status != PSA_SUCCESS) {
-        goto err_release_op;
-    }
-
-    /* Free resources associated with the key derivation operation */
-    status = psa_key_derivation_abort(&op);
-    if (status != PSA_SUCCESS) {
-        goto err_release_key;
-    }
-
     if (encrypt) {
-        status = psa_aead_encrypt(key,
+        status = cracen_aead_encrypt(&attributes,
+                                  key_out,
+                                  sizeof(key_out),
                                   TFM_ITS_AEAD_ALG,
                                   ctx->nonce,
                                   ctx->nonce_size,
@@ -198,34 +166,28 @@ psa_status_t tfm_hal_its_get_aead(struct tfm_hal_its_auth_crypt_ctx *ctx,
                                   ciphertext_size,
                                   &ciphertext_length);
     } else {
-        status = psa_aead_decrypt(key,
+        status = cracen_aead_decrypt(&attributes,
+                                  key_out,
+                                  sizeof(key_out),
                                   TFM_ITS_AEAD_ALG,
                                   ctx->nonce,
                                   ctx->nonce_size,
                                   ctx->aad,
                                   ctx->add_size,
-                                  ciphertext,
-                                  ciphertext_size,
                                   plaintext,
                                   plaintext_size,
+                                  ciphertext,
+                                  ciphertext_size,
                                   &ciphertext_length);
     }
     if(status != PSA_SUCCESS){
-        goto err_release_key;
+        return status;
     }
 
     /* copy tag from ciphertext buffer to tag buffer */
     memcpy(tag, ciphertext + ciphertext_length - tag_length, tag_length);
 
-err_release_key:
-    (void)psa_destroy_key(key);
-
     return status;
-
-err_release_op:
-    (void)psa_key_derivation_abort(&op);
-
-    return PSA_ERROR_GENERIC_ERROR;
 }
 
 enum tfm_hal_status_t tfm_hal_its_aead_encrypt(struct tfm_hal_its_auth_crypt_ctx *ctx,
@@ -268,6 +230,9 @@ enum tfm_hal_status_t tfm_hal_its_aead_decrypt(struct tfm_hal_its_auth_crypt_ctx
                                                tag_size,
                                                false);
 
+    if (status != PSA_SUCCESS) {
+        return TFM_HAL_ERROR_GENERIC;
+    }
+
     return TFM_HAL_SUCCESS;
 }
-


### PR DESCRIPTION
!fixup [nrf noup] platform: nordic_nrf: Add support for 54l

Due to dependencies problems between the ITS and crypto partitions refactoring the ITS encryption interface to use the HUK library and the cracen driver directly.