### PR TITLE
[nrf fromtree] Platform: nordic_nrf: Don't configure NRF_VMC as non-s…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -1285,7 +1285,6 @@ static const uint32_t target_peripherals[] = {
 #ifdef NRF_P1
     NRF_P1_S_BASE,
 #endif
-    NRF_VMC_S_BASE,
 };
 
     for (int i = 0; i < ARRAY_SIZE(target_peripherals); i++) {


### PR DESCRIPTION
…ecure

Dont configure the volatile memory controller as a non-secure peripheral

Change-Id: I2489defaf6deb89beba7447ba079ea3e5afebca5