### PR TITLE
[nrf fromtree] platform: nordic: Add platform memory write service

### DIFF
--- a/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/lairdconnectivity/bl5340_dvk_cpuapp/services/include/tfm_platform_user_memory_ranges.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef TFM_READ_RANGES_H__
-#define TFM_READ_RANGES_H__
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
 
 #include <tfm_ioctl_core_api.h>
 
@@ -33,4 +33,9 @@ static const struct tfm_read_service_range ranges[] = {
 	{ .start = FICR_XOSC32MTRIM_ADDR, .size = FICR_XOSC32MTRIM_SIZE },
 };
 
-#endif /* TFM_READ_RANGES_H__ */
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -29,8 +29,8 @@ extern "C" {
  */
 enum tfm_platform_ioctl_core_reqest_types_t {
 	TFM_PLATFORM_IOCTL_READ_SERVICE,
+	TFM_PLATFORM_IOCTL_WRITE32_SERVICE,
 	TFM_PLATFORM_IOCTL_GPIO_SERVICE,
-
 	/* Last core service, start platform specific from this value. */
 	TFM_PLATFORM_IOCTL_CORE_LAST
 };
@@ -47,6 +47,20 @@ struct tfm_read_service_args_t {
 /** @brief Output list for each read platform service
  */
 struct tfm_read_service_out_t {
+	uint32_t result;
+};
+
+/** @brief Argument list for each platform write32 service.
+ */
+struct tfm_write32_service_args_t {
+	uint32_t addr;
+	uint32_t value;
+	uint32_t mask;
+};
+/** @brief Output list for each write32 platform service
+ */
+
+struct tfm_write32_service_out_t {
 	uint32_t result;
 };
 
@@ -88,11 +102,40 @@ struct tfm_gpio_service_out {
 enum tfm_platform_err_t tfm_platform_mem_read(void *destination, uint32_t addr,
 					      size_t len, uint32_t *result);
 
+/**
+ * @brief Perform a write32 operation.
+ *
+ * @param[in]  addr          Address to write to
+ * @param[in]  value         32 bit value to write
+ * @param[in]  mask          Mask applied to the write value
+ * @param[out] result        An enum tfm_write32_service_result value
+ *
+ * @return Returns values as specified by the tfm_platform_err_t
+ */
+enum tfm_platform_err_t tfm_platform_mem_write32(uint32_t addr, uint32_t value,
+						 uint32_t mask, uint32_t *result);
+
 /** @brief Represents an accepted read range.
  */
 struct tfm_read_service_range {
 	uint32_t start;
 	size_t size;
+};
+
+/** @brief Represents the accepted addresses and masks for write32 service.
+ */
+struct tfm_write32_service_address {
+	uint32_t addr;
+	uint32_t mask;
+	const uint32_t *allowed_values;
+	const uint32_t allowed_values_array_size;
+};
+
+enum tfm_write32_service_result {
+	TFM_WRITE32_SERVICE_SUCCESS,
+	TFM_WRITE32_SERVICE_ERROR_INVALID_ADDRESS,
+	TFM_WRITE32_SERVICE_ERROR_INVALID_MASK,
+	TFM_WRITE32_SERVICE_ERROR_INVALID_VALUE,
 };
 
 /**

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
@@ -26,6 +26,11 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 enum tfm_platform_err_t
 tfm_platform_hal_gpio_service(const psa_invec  *in_vec, const psa_outvec *out_vec);
 
+
+enum tfm_platform_err_t
+tfm_platform_hal_write32_service(const psa_invec  *in_vec,
+				 const psa_outvec *out_vec);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -66,3 +66,31 @@ enum tfm_platform_err_t tfm_platform_gpio_pin_mcu_select(uint32_t pin_number, ui
 	return TFM_PLATFORM_ERR_NOT_SUPPORTED;
 #endif
 }
+
+enum tfm_platform_err_t tfm_platform_mem_write32(uint32_t addr, uint32_t value,
+						 uint32_t mask, uint32_t *result)
+{
+	enum tfm_platform_err_t ret;
+	psa_invec in_vec;
+	psa_outvec out_vec;
+	struct tfm_write32_service_args_t args;
+	struct tfm_write32_service_out_t out;
+
+	in_vec.base = (const void *)&args;
+	in_vec.len = sizeof(args);
+
+	out_vec.base = (void *)&out;
+	out_vec.len = sizeof(out);
+
+	args.addr = addr;
+	args.value = value;
+	args.mask = mask;
+	/* Allowed values cannot be specified by the user */
+
+	ret = tfm_platform_ioctl(TFM_PLATFORM_IOCTL_WRITE32_SERVICE, &in_vec,
+				 &out_vec);
+
+	*result = out.result;
+
+	return ret;
+}

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -14,7 +14,7 @@
 #include <tfm_hal_isolation.h>
 
 /* This contains the user provided allowed ranges */
-#include <tfm_read_ranges.h>
+#include <tfm_platform_user_memory_ranges.h>
 
 #include <hal/nrf_gpio.h>
 
@@ -133,3 +133,76 @@ tfm_platform_hal_gpio_service(const psa_invec  *in_vec, const psa_outvec *out_ve
 }
 #endif /* NRF_GPIO_HAS_SEL */
 
+enum tfm_platform_err_t tfm_platform_hal_write32_service(const psa_invec *in_vec,
+							 const psa_outvec *out_vec)
+{
+	uint32_t addr;
+	uint32_t mask;
+	uint32_t allowed_values_array_size;
+
+	struct tfm_write32_service_args_t *args;
+	struct tfm_write32_service_out_t *out;
+
+	enum tfm_platform_err_t err;
+
+	if (in_vec->len != sizeof(struct tfm_write32_service_args_t) ||
+	    out_vec->len != sizeof(struct tfm_write32_service_out_t)) {
+		return TFM_PLATFORM_ERR_INVALID_PARAM;
+	}
+
+	args = (struct tfm_write32_service_args_t *)in_vec->base;
+	out = (struct tfm_write32_service_out_t *)out_vec->base;
+
+	/* Assume failure, in case we don't find a match */
+	out->result = TFM_WRITE32_SERVICE_ERROR_INVALID_ADDRESS;
+	err = TFM_PLATFORM_ERR_INVALID_PARAM;
+
+	for (size_t i = 0; i < ARRAY_SIZE(tfm_write32_service_addresses); i++) {
+		addr = tfm_write32_service_addresses[i].addr;
+		mask = tfm_write32_service_addresses[i].mask;
+		allowed_values_array_size =
+			tfm_write32_service_addresses[i].allowed_values_array_size;
+
+		if (args->addr == addr) {
+			out->result = TFM_WRITE32_SERVICE_ERROR_INVALID_MASK;
+
+			if (args->mask == mask) {
+				/* Check for allowed values if provided */
+				if (allowed_values_array_size > 0 &&
+				    tfm_write32_service_addresses[i].allowed_values != NULL) {
+					bool is_value_allowed = false;
+
+					for (int j = 0; j < allowed_values_array_size; j++) {
+
+						const uint32_t allowed_value =
+							tfm_write32_service_addresses[i]
+								.allowed_values[j];
+
+						if (allowed_value == (args->value & args->mask)) {
+							is_value_allowed = true;
+							break;
+						}
+					}
+
+					if (!is_value_allowed) {
+						out->result =
+							TFM_WRITE32_SERVICE_ERROR_INVALID_VALUE;
+						break;
+					}
+				}
+
+				uint32_t new_value = *(uint32_t *)addr;
+				/* Invert the mask to convert the masked bits to 0 first */
+				new_value &= ~args->mask;
+				new_value |= (args->value & args->mask);
+				*(uint32_t *)addr = new_value;
+
+				out->result = TFM_WRITE32_SERVICE_SUCCESS;
+				err = TFM_PLATFORM_ERR_SUCCESS;
+				break;
+			}
+		}
+	}
+
+	return err;
+}

--- a/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/services/include/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/services/include/tfm_platform_user_memory_ranges.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef TFM_READ_RANGES_H__
-#define TFM_READ_RANGES_H__
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
 
 #include <tfm_ioctl_core_api.h>
 
@@ -33,4 +33,9 @@ static const struct tfm_read_service_range ranges[] = {
 	{ .start = FICR_XOSC32MTRIM_ADDR, .size = FICR_XOSC32MTRIM_SIZE },
 };
 
-#endif /* TFM_READ_RANGES_H__ */
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/services/include/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/services/include/tfm_platform_user_memory_ranges.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef TFM_READ_RANGES_H__
-#define TFM_READ_RANGES_H__
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
 
 #include <tfm_ioctl_core_api.h>
 
@@ -25,4 +25,9 @@ static const struct tfm_read_service_range ranges[] = {
 	{ .start = FICR_RESTRICTED_ADDR, .size = FICR_RESTRICTED_SIZE },
 };
 
-#endif /* TFM_READ_RANGES_H__ */
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */

--- a/platform/ext/target/nordic_nrf/nrf9161dk_nrf9161/services/include/tfm_platform_user_memory_ranges.h
+++ b/platform/ext/target/nordic_nrf/nrf9161dk_nrf9161/services/include/tfm_platform_user_memory_ranges.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef TFM_READ_RANGES_H__
-#define TFM_READ_RANGES_H__
+#ifndef TFM_PLATFORM_USER_MEMORY_RANGES_H__
+#define TFM_PLATFORM_USER_MEMORY_RANGES_H__
 
 #include <tfm_ioctl_core_api.h>
 
@@ -25,4 +25,9 @@ static const struct tfm_read_service_range ranges[] = {
 	{ .start = FICR_RESTRICTED_ADDR, .size = FICR_RESTRICTED_SIZE },
 };
 
-#endif /* TFM_READ_RANGES_H__ */
+static const struct tfm_write32_service_address tfm_write32_service_addresses[] = {
+	/* This is a dummy value because this table cannot be empty */
+	{.addr = 0xFFFFFFFF, .mask = 0x0, .allowed_values = NULL, .allowed_values_array_size = 0},
+};
+
+#endif /* TFM_PLATFORM_USER_MEMORY_RANGES_H__ */


### PR DESCRIPTION
There are some hardware registers in Nordic platforms which are mapped as secure only. In order to allow the non-secure application to control these registers I added here a secure service which allows 32-bit writes to secure mapped memory. The writes are only allowed on  addresses and masks defined in a header list. It is also possible to provide an allowed_values list in order to further limit the accepted values.

Renamed:  tfm_read_ranges.h -> tfm_platform_user_memory_ranges.h since now it can be used for both reads and writes.

The list in the current platforms is empty and might be populated later.

Signed-off-by: Georgios Vasilakis <georgios.vasilakis@nordicsemi.no>