### PR TITLE
[nrf noup] Fix version warning

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -16,7 +16,7 @@ execute_process(COMMAND git describe --tags --always
 # In a repository cloned with --no-tags option TFM_VERSION_FULL will be a hash
 # only hence checking it for a tag format to accept as valid version.
 
-string(FIND ${TFM_VERSION_FULL} "TF-M" TFM_TAG)
+string(FIND ${TFM_VERSION_FULL} "v" TFM_TAG)
 if(TFM_TAG EQUAL -1)
     set(TFM_VERSION_FULL v${TFM_VERSION_MANUAL})
     message(WARNING "Actual TF-M version is not available from Git repository. Settled to " ${TFM_VERSION_FULL})


### PR DESCRIPTION
Version check depends on upstream's tagging scheme which differs from NCS's