### PR TITLE
[nrf noup] platform: ext: nordic_nrf: Custom nRF54L15 linker section

### DIFF
--- a/platform/ext/common/gcc/tfm_common_s.ld
+++ b/platform/ext/common/gcc/tfm_common_s.ld
@@ -261,6 +261,15 @@ SECTIONS
     VENEERS()
 #endif
 
+#if defined(CONFIG_PSA_NEED_CRACEN_KMU_DRIVER)
+    .nrf_kmu_reserved_push_area S_DATA_START:
+    {
+        __nrf_kmu_reserved_push_area = .;
+        *(.nrf_kmu_reserved_push_area)
+        __nrf_kmu_reserved_push_area_end = .;
+    } > RAM
+#endif /* CONFIG_PSA_NEED_CRACEN_KMU_DRIVER */
+
     /**** Base address of secure data area */
     .tfm_secure_data_start :
     {


### PR DESCRIPTION
Add a custom section in the linker script for the CRACEN KMU driver use by nRF54L15. We need a buffer in a static memory location which wil be used by the KMU to perform push operations.

It's a noup since the KMU is not supported fully upstream yet.

Ref: NCSDK-25121