### PR TITLE
[noup] KMU: Add NOLOAD to linker section for the nRF KMU region

### DIFF
--- a/platform/ext/common/gcc/tfm_common_s.ld
+++ b/platform/ext/common/gcc/tfm_common_s.ld
@@ -262,7 +262,7 @@ SECTIONS
 #endif
 
 #if defined(CONFIG_PSA_NEED_CRACEN_KMU_DRIVER)
-    .nrf_kmu_reserved_push_area S_DATA_START:
+    .nrf_kmu_reserved_push_area S_DATA_START (NOLOAD):
     {
         __nrf_kmu_reserved_push_area = .;
         *(.nrf_kmu_reserved_push_area)


### PR DESCRIPTION
This was missed in a previous commit without this the linker will place the initialization of this global variable which is 0 at the address of S_DATA_START in Flash,now it will be discarded.

Ref. NCSDK-25121