### PR TITLE
UART fixes for nRF54l

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
+++ b/platform/ext/target/nordic_nrf/common/core/cmsis_drivers/Driver_USART.c
@@ -28,7 +28,7 @@
 #define ARRAY_SIZE(arr) (sizeof(arr)/sizeof(arr[0]))
 #endif
 
-#if !(DOMAIN_NS == 1U) && defined(CONFIG_TFM_LOG_SHARE_UART) && defined(NRF_SPU)
+#if !(DOMAIN_NS == 1U) && defined(CONFIG_TFM_LOG_SHARE_UART) && (defined(NRF_SPU) || defined(NRF_SPU00))
 #define SPU_CONFIGURE_UART
 #include <spu.h>
 #endif

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -872,6 +872,9 @@ enum tfm_plat_err_t init_debug(void)
     return TFM_PLAT_ERR_SUCCESS;
 }
 
+#define NRF_UARTE_INSTANCE(id) NRF_UARTE ## id
+#define NRF_UARTE_INSTANCE_GET(id) NRF_UARTE_INSTANCE(id)
+
 /*----------------- NVIC interrupt target state to NS configuration ----------*/
 enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void)
 {
@@ -893,26 +896,8 @@ enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void)
 #endif
 
 #ifdef SECURE_UART1
-#if NRF_SECURE_UART_INSTANCE == 0
-    /* UARTE0 is a secure peripheral, so its IRQ has to target S state */
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE0));
-#elif NRF_SECURE_UART_INSTANCE == 1
-    /* UARTE1 is a secure peripheral, so its IRQ has to target S state */
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE1));
-#elif NRF_SECURE_UART_INSTANCE == 30
-    /* UARTE30 is a secure peripheral, so its IRQ has to target S state */
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE30));
-#elif NRF_SECURE_UART_INSTANCE == 00
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE00));
-#elif NRF_SECURE_UART_INSTANCE == 20
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE20));
-#elif NRF_SECURE_UART_INSTANCE == 21
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE21));
-#elif NRF_SECURE_UART_INSTANCE == 22
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE22));
-#elif NRF_SECURE_UART_INSTANCE == 30
-    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE30));
-#endif
+    /* IRQ for the selected secure UART has to target S state */
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE_INSTANCE_GET(NRF_SECURE_UART_INSTANCE)));
 #endif
 
     return TFM_PLAT_ERR_SUCCESS;

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -902,6 +902,16 @@ enum tfm_plat_err_t nvic_interrupt_target_state_cfg(void)
 #elif NRF_SECURE_UART_INSTANCE == 30
     /* UARTE30 is a secure peripheral, so its IRQ has to target S state */
     NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE30));
+#elif NRF_SECURE_UART_INSTANCE == 00
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE00));
+#elif NRF_SECURE_UART_INSTANCE == 20
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE20));
+#elif NRF_SECURE_UART_INSTANCE == 21
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE21));
+#elif NRF_SECURE_UART_INSTANCE == 22
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE22));
+#elif NRF_SECURE_UART_INSTANCE == 30
+    NVIC_ClearTargetState(NRFX_IRQ_NUMBER_GET(NRF_UARTE30));
 #endif
 #endif
 
@@ -1260,6 +1270,7 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
 	memset(NRF_SPU20, 0, sizeof(NRF_SPU_Type));
 	memset(NRF_SPU30, 0, sizeof(NRF_SPU_Type));
 
+#if SECURE_UART1
 	/* Configure TF-M's UART peripheral to be secure */
 #if NRF_SECURE_UART_INSTANCE == 00
     uint32_t uart_periph_start = tfm_peripheral_uarte00.periph_start;
@@ -1277,6 +1288,7 @@ enum tfm_plat_err_t spu_periph_init_cfg(void)
     uint32_t uart_periph_start = tfm_peripheral_uarte30.periph_start;
 #endif
 	spu_peripheral_config_secure(uart_periph_start, SPU_LOCK_CONF_LOCKED);
+#endif
 
 	/* Configure the CTRL-AP mailbox interface to be secure as it is used by the secure ADAC service */
 	spu_peripheral_config_secure(NRF_CTRLAP_S_BASE, SPU_LOCK_CONF_LOCKED);


### PR DESCRIPTION
Fix some configuration issues with the secure UART which caused build failures or TF-M panics. In essence what these changes do is that:
1) Make sure that if no secure UART is being enabled we don't include any UART configuration code. 
2) Make sure that the configuration of the UART includes all the available UART ports.