### PR TITLE
[nrf fromtree] platform: nordic_nrf: APPROTECT to lock debugging

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -209,6 +209,20 @@ if(BL2)
     )
 endif()
 
+if(NRF_APPROTECT)
+    target_compile_definitions(tfm_spm
+    PRIVATE
+        NRF_APPROTECT
+    )
+endif()
+
+if(NRF_SECURE_APPROTECT)
+    target_compile_definitions(tfm_spm
+    PRIVATE
+        NRF_SECURE_APPROTECT
+    )
+endif()
+
 #========================= Files for building NS side platform ================#
 
 configure_file(config_nordic_nrf_spe.cmake.in

--- a/platform/ext/target/nordic_nrf/common/core/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/core/config.cmake
@@ -33,6 +33,9 @@ if (NRF_HW_INIT_NRF_PERIPHERALS AND NOT NRF_HW_INIT_RESET_ON_BOOT)
         message(FATAL_ERROR "NRF_HW_INIT_NRF_PERIPHERALS depends on NRF_HW_INIT_RESET_ON_BOOT")
 endif()
 
+set(NRF_APPROTECT                       OFF        CACHE BOOL      "Enable approtect")
+set(NRF_SECURE_APPROTECT                OFF        CACHE BOOL      "Enable secure approtect")
+
 # Platform-specific configurations
 set(CONFIG_TFM_USE_TRUSTZONE            ON)
 set(TFM_MULTI_CORE_TOPOLOGY             OFF)

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -807,7 +807,33 @@ enum tfm_plat_err_t system_reset_cfg(void)
 
 enum tfm_plat_err_t init_debug(void)
 {
-#if defined(NRF91_SERIES) || defined(NRF54L15_ENGA_XXAA)
+#if defined(NRF_APPROTECT) || defined(NRF_SECURE_APPROTECT)
+
+#if !defined(DAUTH_CHIP_DEFAULT)
+#error "Debug access controlled by NRF_APPROTECT and NRF_SECURE_APPROTECT."
+#endif
+
+#if defined(NRF_APPROTECT)
+    /* For nRF53 and nRF91x1 already active. For nRF9160, active in the next boot.*/
+    if (nrfx_nvmc_word_writable_check((uint32_t)&NRF_UICR_S->APPROTECT,
+                                    UICR_APPROTECT_PALL_Protected)) {
+        nrfx_nvmc_word_write((uint32_t)&NRF_UICR_S->APPROTECT, UICR_APPROTECT_PALL_Protected);
+    } else {
+        return TFM_PLAT_ERR_SYSTEM_ERR;
+    }
+#endif
+#if defined(NRF_SECURE_APPROTECT)
+    /* For nRF53 and nRF91x1 already active. For nRF9160, active in the next boot. */
+    if (nrfx_nvmc_word_writable_check((uint32_t)&NRF_UICR_S->SECUREAPPROTECT,
+                                    UICR_SECUREAPPROTECT_PALL_Protected)) {
+        nrfx_nvmc_word_write((uint32_t)&NRF_UICR_S->SECUREAPPROTECT,
+            UICR_SECUREAPPROTECT_PALL_Protected);
+    } else {
+        return TFM_PLAT_ERR_SYSTEM_ERR;
+    }
+#endif
+
+#elif defined(NRF91_SERIES) || defined(NRF54L15_ENGA_XXAA)
 
 #if !defined(DAUTH_CHIP_DEFAULT)
 #error "Debug access on this platform can only be configured by programming the corresponding registers in UICR."


### PR DESCRIPTION
NRF_APPROTECT and NRF_SECURE_APPROTECT
to take precedence over other mechanisms when configuring debugging for TF-M.

For nRF53 and nRF91x1 the actual locking of firmware is done elsewhere. This further locks the UICR.

nRF9160 supports only hardware APPROTECT. This will lock the APPROTECT / SECUREAPPROTECT in the next boot, when the above settings are configured.

Change-Id: I5e304be0f8a34c0016488d9ec09929bbcb38481f
Signed-off-by: Markus Lassila <markus.lassila@nordicsemi.no>
(cherry picked from commit 734a51d3b18422ad516e08e7ddc107e921d64180)