### PR TITLE
[nrf noup] platform: nordic_nrf: Remove unused define for nRF54L15

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -80,7 +80,6 @@ static bool valid_mcu_select(uint32_t mcu)
 	case NRF_GPIO_PIN_SEL_GPIO:
 	case NRF_GPIO_PIN_SEL_VPR:
 	case NRF_GPIO_PIN_SEL_GRTC:
-	case NRF_GPIO_PIN_SEL_TND:
 #else
 	case NRF_GPIO_PIN_SEL_APP:
 	case NRF_GPIO_PIN_SEL_NETWORK:


### PR DESCRIPTION
fixup! [nrf noup] platform: nordic_nrf: Add support for 54l

The latest nrfx removes the define NRF_GPIO_PIN_SEL_TND for the nRF54L15 indirectly since it removes the define: GPIO_PIN_CNF_MCUSEL_TND and the GPIO_PIN_CNF_CTRLSEL_TND is also not defined.