### PR TITLE
[nrf fromtree] platform: nordic: Allow reading UICR registers

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -17,6 +17,7 @@
 #include <tfm_platform_user_memory_ranges.h>
 
 #include <hal/nrf_gpio.h>
+#include <nrfx_nvmc.h>
 
 #include "handle_attr.h"
 
@@ -60,6 +61,29 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 
 		if (args->addr >= start &&
 		    args->addr + args->len <= start + size) {
+#ifdef NRF_UICR_S_BASE
+			if (start >= NRF_UICR_S_BASE &&
+			    start < (NRF_UICR_S_BASE + sizeof(NRF_UICR_Type))) {
+				/* Range is inside UICR. Some nRF platforms need special handling */
+				uint32_t *src = (uint32_t *)args->addr;
+				uint32_t *dst = (uint32_t *)args->destination;
+				uint32_t uicr_end = NRF_UICR_S_BASE + sizeof(NRF_UICR_Type);
+
+				if (!IS_ALIGNED(src, sizeof(uint32_t)) ||
+				    (args->len % sizeof(uint32_t)) != 0 ||
+				    (args->addr + args->len) > uicr_end) {
+					return TFM_PLATFORM_ERR_NOT_SUPPORTED;
+				}
+
+				while (args->len) {
+					*dst++ = nrfx_nvmc_uicr_word_read(src++);
+					args->len -= sizeof(uint32_t);
+				}
+				out->result = 0;
+				err = TFM_PLATFORM_ERR_SUCCESS;
+				break;
+			}
+#endif
 			memcpy(args->destination,
 			       (const void *)args->addr,
 			       args->len);

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -17,7 +17,9 @@
 #include <tfm_platform_user_memory_ranges.h>
 
 #include <hal/nrf_gpio.h>
+#ifdef NRF91_SERIES
 #include <nrfx_nvmc.h>
+#endif
 
 #include "handle_attr.h"
 
@@ -61,7 +63,7 @@ tfm_platform_hal_read_service(const psa_invec  *in_vec,
 
 		if (args->addr >= start &&
 		    args->addr + args->len <= start + size) {
-#ifdef NRF_UICR_S_BASE
+#ifdef NRF91_SERIES
 			if (start >= NRF_UICR_S_BASE &&
 			    start < (NRF_UICR_S_BASE + sizeof(NRF_UICR_Type))) {
 				/* Range is inside UICR. Some nRF platforms need special handling */


### PR DESCRIPTION
On certain nRF plaforms, like nRF9160, reading UICR registers might need special handling, which is already implemented in nrfx_nvmc_uicr_word_read() so use that, instead on memcpy().

For more information, see nRF9160 Errata 7.

Change-Id: Iea9d0bf4184decd5650b4d4b620fbef0c64a55f6
Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>
(cherry picked from commit ca03e40149cc7a376c7d8f5511df60431b832929)