### PR TITLE
[nrf noup] platform: nordic_nrf: nRF54L15 does not have UICR

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg.c
@@ -814,7 +814,7 @@ enum tfm_plat_err_t init_debug(void)
 #error "Debug access controlled by NRF_APPROTECT and NRF_SECURE_APPROTECT."
 #endif
 
-#if defined(NRF_APPROTECT)
+#if defined(NRF_APPROTECT) && !defined(NRF54L15_XXAA)
     /* For nRF53 and nRF91x1 already active. For nRF9160, active in the next boot.*/
     if (nrfx_nvmc_word_writable_check((uint32_t)&NRF_UICR_S->APPROTECT,
                                     UICR_APPROTECT_PALL_Protected)) {
@@ -823,7 +823,7 @@ enum tfm_plat_err_t init_debug(void)
         return TFM_PLAT_ERR_SYSTEM_ERR;
     }
 #endif
-#if defined(NRF_SECURE_APPROTECT)
+#if defined(NRF_SECURE_APPROTECT) && !defined(NRF54L15_XXAA)
     /* For nRF53 and nRF91x1 already active. For nRF9160, active in the next boot. */
     if (nrfx_nvmc_word_writable_check((uint32_t)&NRF_UICR_S->SECUREAPPROTECT,
                                     UICR_SECUREAPPROTECT_PALL_Protected)) {


### PR DESCRIPTION
Do not attempt to lock the UICR.APPROTECT or UICR.SECUREAPPROTECT for nRF54L15. These registers do not exist.

TF-M provisioning with nRF54L15 will still result in compilation failure. As it should at this point.