### PR TITLE
[nrf fromtree] Protected Storage: Add capacity in tfm_ps_get_info calls.

### DIFF
--- a/secure_fw/partitions/protected_storage/ps_object_system.c
+++ b/secure_fw/partitions/protected_storage/ps_object_system.c
@@ -480,6 +480,7 @@ psa_status_t ps_object_get_info(psa_storage_uid_t uid, int32_t client_id,
 
     /* Copy PS object info to the PSA PS info struct */
     info->size = g_ps_object.header.info.current_size;
+    info->capacity = g_ps_object.header.info.max_size;
     info->flags = g_ps_object.header.info.create_flags;
 
 clear_data_and_return:


### PR DESCRIPTION
Add missing capacity in tfm_ps_get_info calls.

Change-Id: I37432d204ee87971915471dce9b3a2ebcce057e2
Signed-off-by: Markus Lassila <markus.lassila@nordicsemi.no>
(cherry picked from commit fafe163c21736bf454568e28510da8977215f287)