### PR TITLE
[nrf fromtree] platform: nrf: ifdef nrf_rtc.h inclusion

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/hw_init.c
+++ b/platform/ext/target/nordic_nrf/common/core/hw_init.c
@@ -10,7 +10,9 @@
 #include "array.h"
 
 #include <nrfx.h>
+#if defined(RTC_PRESENT)
 #include <hal/nrf_rtc.h>
+#endif
 #include <hal/nrf_uarte.h>
 #include <hal/nrf_clock.h>
 #include <hal/nrf_dppi.h>


### PR DESCRIPTION
Some devices do not have RTC peripheral.

Upstream PR #: 35302