### PR TITLE
Protected Storage: Do not align NV counters in init

### DIFF
--- a/secure_fw/partitions/protected_storage/ps_object_table.c
+++ b/secure_fw/partitions/protected_storage/ps_object_table.c
@@ -902,14 +902,6 @@ psa_status_t ps_object_table_init(uint8_t *obj_data)
         return err;
     }
 
-#if PS_ROLLBACK_PROTECTION
-    /* Align PS NV counters */
-    err = ps_object_table_align_nv_counters(init_ctx.nvc_1);
-    if (err != PSA_SUCCESS) {
-        return err;
-    }
-#endif /* PS_ROLLBACK_PROTECTION */
-
 #ifdef PS_ENCRYPTION
     ps_crypto_set_iv(&ps_obj_table_ctx.obj_table.crypto);
 #endif


### PR DESCRIPTION
NVC_2 and NVC_3 should not be aligned to NVC_1 unless the object table has been successfully stored to persistent memory.

When storing an object to PS, the object is stored first and the object table is updated afterwards. If there is not enough memory for the object table, NVC_1 is increased, but NVC_2 and NVC_3 are not. Reset the device. Object table is validated with NVC_3. Now, if NVC_2 and NVC_3 are brought to be on par with NVC_1 and the object table is not saved and the device is reset again, the object table can no longer be validated. New object tables are created, which loses all the data stored to PS.

Change-Id: I9eb680d507d5aac251bede586b6c39c751815dcb
Signed-off-by: Markus Lassila <markus.lassila@nordicsemi.no>
(cherry picked from commit c08e9ef89a35a546291af699f378ee9acc661fa7)