### PR TITLE
(2.9) [nrf noup] Remove version mismatch CMake warning

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -25,8 +25,3 @@ string(REGEX REPLACE "TF-M" "" TFM_VERSION_FULL ${TFM_VERSION_FULL})
 # remove a commit number
 string(REGEX REPLACE "-[0-9]+-g" "+" TFM_VERSION_FULL ${TFM_VERSION_FULL})
 string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" TFM_VERSION ${TFM_VERSION_FULL})
-
-# Check that manually set version is up to date
-if (NOT TFM_VERSION_MANUAL STREQUAL TFM_VERSION)
-    message(WARNING "TFM_VERSION_MANUAL mismatches to actual TF-M version. Please update TFM_VERSION_MANUAL in cmake/version.cmake")
-endif()


### PR DESCRIPTION
Get rid of the CMake warning which happens when `TFM_VERSION_MANUAL` mismatches `TFM_VERSION_FULL`.
The latter is obtained with Git tags, which cannot be relied on in NCS.