### PR TITLE
[nrf noup] secure_fw: partitions: Remove its dependency

### DIFF
--- a/secure_fw/partitions/crypto/tfm_crypto.yaml
+++ b/secure_fw/partitions/crypto/tfm_crypto.yaml
@@ -26,6 +26,8 @@
     },
   ],
   "dependencies": [
+  ],
+  "weak_dependencies": [
     "TFM_INTERNAL_TRUSTED_STORAGE_SERVICE"
   ]
 }

--- a/tools/tfm_manifest_list.yaml
+++ b/tools/tfm_manifest_list.yaml
@@ -81,7 +81,8 @@
            "*mbedcrypto.*",
            "*mbedtls*acceleration.*",
          ]
-      }
+      },
+      "non_ffm_attributes": ['weak_dependencies']
     },
     {
       "description": "TFM Platform Partition",


### PR DESCRIPTION
TFM_CRYPTO depends on TFM_INTERNAL_TRUSTED_STORAGE_SERVICE. This means it is not possible to not use ITS.
This is removed to make it possible to support using crypto without ITS.
This is a noup as it is not possible to do this change upstream. There are platforms upstream that depend on this dependency.

There was an attempt to upstream it here: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/41845
You can read there for more information on why this is a noup