### PR TITLE
[nrf noup] version: Fix TFM_VERSION being undefined

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -8,32 +8,5 @@
 # The 'TFM_VERSION_MANUAL' is used for fallback when Git tags are not available
 set(TFM_VERSION_MANUAL "2.2.0")
 
-if(TRUE)
-    # Git execution fails.
-    # Applying a manual version assuming the code tree is a local copy.
-    set(TFM_VERSION_FULL "v${TFM_VERSION_MANUAL}")
-    return()
-endif()
-
-# In a repository cloned with --no-tags option TFM_VERSION_FULL will be a hash
-# only hence checking it for a tag format to accept as valid version.
-
-string(FIND "${TFM_VERSION_FULL}" "TF-M" TFM_TAG)
-if(TFM_TAG EQUAL -1)
-    execute_process(COMMAND git log --format=format:%h -n 1
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE TFM_GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    set(TFM_VERSION_FULL "v${TFM_VERSION_MANUAL}+g${TFM_GIT_HASH}")
-endif()
-
-string(REGEX REPLACE "TF-M" "" TFM_VERSION_FULL ${TFM_VERSION_FULL})
-# remove a commit number
-string(REGEX REPLACE "-[0-9]+-g" "+" TFM_VERSION_FULL ${TFM_VERSION_FULL})
-string(REGEX MATCH "[0-9]+\\.[0-9]+\\.[0-9]+" TFM_VERSION ${TFM_VERSION_FULL})
-
-# Check that manually set version is up to date
-if (NOT TFM_VERSION_MANUAL STREQUAL TFM_VERSION)
-    message(WARNING "TFM_VERSION_MANUAL mismatches to actual TF-M version. Please update TFM_VERSION_MANUAL in cmake/version.cmake")
-endif()
+set(TFM_VERSION_FULL "v${TFM_VERSION_MANUAL}")
+set(TFM_VERSION "${TFM_VERSION_MANUAL}")

--- a/platform/ext/common/template/flash_otp_nv_counters_backend.h
+++ b/platform/ext/common/template/flash_otp_nv_counters_backend.h
@@ -58,7 +58,7 @@ __PACKED_STRUCT flash_otp_nv_counters_region_t {
         uint8_t implementation_id[32];
         uint8_t cert_ref[32];
         uint8_t verification_service_url[32];
-        uint8_t profile_definition[48];
+        uint8_t profile_definition[32];
 
 #ifdef BL2
         uint8_t bl2_rotpk_0[BL2_ROTPK_SIZE];


### PR DESCRIPTION
nrf-squash! [nrf noup] build: fix TF-M version

Fixes an issue where the TFM_VERSION was not set because the return() statement exited early.

This removes all the logic from the unused logic from the version.cmake since it is irrelevant.