### PR TITLE
[nrf fromtree dirty] Crypto: Allow turning off MBEDTLS_MEMORY_BUFFER_ALLOC_C

### DIFF
--- a/secure_fw/partitions/crypto/crypto_library.c
+++ b/secure_fw/partitions/crypto/crypto_library.c
@@ -56,8 +56,10 @@ static char mbedtls_version_full[18];
  * \brief Static buffer to be used by Mbed Crypto for memory allocations
  *
  */
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
 #include "config_engine_buf.h"
 static uint8_t mbedtls_mem_buf[CRYPTO_ENGINE_BUF_SIZE] = {0};
+#endif
 
 /* Make sure the library won't print anything through mbedtls_printf */
 static int null_printf(const char *fmt, ...)
@@ -89,12 +91,18 @@ psa_status_t tfm_crypto_core_library_init(void)
     /* Initialise the Mbed Crypto memory allocator to use static memory
      * allocation from the provided buffer instead of using the heap
      */
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     mbedtls_memory_buffer_alloc_init(mbedtls_mem_buf,
                                      CRYPTO_ENGINE_BUF_SIZE);
+#endif
 
     mbedtls_platform_set_printf(null_printf);
 
+#if defined(MBEDTLS_MEMORY_BUFFER_ALLOC_C)
     LOG_DBGFMT("[DBG][Crypto] Internal heap size is %d bytes\r\n", sizeof(mbedtls_mem_buf));
+#else
+    LOG_DBGFMT("[DBG][Crypto] No internal heap\r\n");
+#endif
 
     return PSA_SUCCESS;
 }


### PR DESCRIPTION
This removes a faulty requirement to always enable heap regardless if TF-M is using it. 
In the sdk-nrf commit that uses this, we use this to get the build size down for TF-M minimal profile.

The proposed change is already taken in upstream TF-M, changed to [nrf fromtree dirty]