### PR TITLE
[nrf noup] crypto: Fix missing WPA3 prerequisite for PAKE

### DIFF
--- a/secure_fw/partitions/crypto/crypto_check_config.h
+++ b/secure_fw/partitions/crypto/crypto_check_config.h
@@ -124,7 +124,9 @@
      !defined(PSA_WANT_ALG_SPAKE2P_CMAC) && \
      !defined(PSA_WANT_ALG_SPAKE2P_MATTER) && \
      !defined(PSA_WANT_ALG_SRP_6) && \
-     !defined(PSA_WANT_ALG_SRP_PASSWORD_HASH))
+     !defined(PSA_WANT_ALG_SRP_PASSWORD_HASH) && \
+     !defined(PSA_WANT_ALG_WPA3_SAE_FIXED) && \
+     !defined(PSA_WANT_ALG_WPA3_SAE_GDH))
 #error "CRYPTO_PAKE_MODULE_ENABLED enabled, but not all prerequisites (missing PAKE algorithms)!"
 #endif
 


### PR DESCRIPTION
Fixes the build time error stating that PAKE is enabled, but not all prerequisites if WPA3 is the only activated PAKE algorithm.