### PR TITLE
[nrf noup]platform: nordic_nrf: Add support for TFM_SHARED_INSTANCE

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/native_drivers/spu.c
+++ b/platform/ext/target/nordic_nrf/common/core/native_drivers/spu.c
@@ -351,7 +351,9 @@ void spu_peripheral_config_secure(const uint32_t periph_base_address, bool perip
 
 	nrf_spu_periph_perm_secattr_set(nrf_spu, index, true /* Secure */);
 	nrf_spu_periph_perm_dmasec_set(nrf_spu, index, true /* Secure */);
-	nrf_spu_periph_perm_lock_enable(nrf_spu, index);
+	if (periph_lock) {
+		nrf_spu_periph_perm_lock_enable(nrf_spu, index);
+	}
 #endif
 }
 
@@ -379,6 +381,8 @@ void spu_peripheral_config_non_secure(const uint32_t periph_base_address, bool p
 
 	nrf_spu_periph_perm_secattr_set(nrf_spu, index, false /* Non-Secure */);
 	nrf_spu_periph_perm_dmasec_set(nrf_spu, index, false /* Non-Secure */);
-	nrf_spu_periph_perm_lock_enable(nrf_spu, index);
+	if (periph_lock) {
+		nrf_spu_periph_perm_lock_enable(nrf_spu, index);
+	}
 #endif
 }

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
@@ -302,7 +302,12 @@ void peripheral_configuration(void)
 #else
 #error "Unsupported NRF_SECURE_UART_INSTANCE for nrf54l series. Supported instances: 00, 20, 21, 22, 30"
 #endif
+
+#if defined(CONFIG_TFM_LOG_SHARE_UART)
+	spu_peripheral_config_secure(uart_periph_start, SPU_LOCK_CONF_UNLOCKED);
+#else
 	spu_peripheral_config_secure(uart_periph_start, SPU_LOCK_CONF_LOCKED);
+#endif
 #endif /* SECURE_UART1 */
 
 	/* Configure the CTRL-AP mailbox interface to be secure as it is used by the secure ADAC

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -314,7 +314,12 @@ void peripheral_configuration(void)
 #else
 #error "Unsupported NRF_SECURE_UART_INSTANCE for nrf71 series. Supported instances: 00, 20, 21, 22, 30"
 #endif
+
+#if defined(CONFIG_TFM_LOG_SHARE_UART)
+	spu_peripheral_config_secure(uart_periph_start, SPU_LOCK_CONF_UNLOCKED);
+#else
 	spu_peripheral_config_secure(uart_periph_start, SPU_LOCK_CONF_LOCKED);
+#endif
 #endif /* SECURE_UART1 */
 
 	/* Configure the CTRL-AP mailbox interface to be secure as it is used by the secure ADAC


### PR DESCRIPTION
UART instances would be locked permanently even when TFM_SHARED_INSTANCE was set.
Update to allow shared instance for UART on
54L and 71 series devices.
TFM_SHARED_INSTANCE is a NCS config
which is why this is a noup.