### PR TITLE
[nrf fromtree] platform: nordic_nrf: nrf7120: Enable NS MCUboot build

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -223,11 +223,53 @@ enum tfm_plat_err_t nrf_mpc_init_cfg(void)
 		init_mpc_region_override(&override);
 
 		override.start_address = memory_regions.non_secure_partition_base;
+#if defined(NRF_NS_SECONDARY) || defined(NRF_NS_STORAGE_PARTITION_START)
+		/* If there is a secondary partition, the non-secure partition limit
+		 * is the start of the secondary partition.
+		 */
+		override.endaddr = memory_regions.non_secure_partition_limit;
+#else
+		override.endaddr = NRF_UICR_S_BASE;
+#endif
+		override.index = index_mpc00++;
+
+		mpc_configure_override(NRF_MPC00, &override);
+	}
+
+#ifdef NRF_NS_SECONDARY
+	{
+		struct mpc_region_override override;
+
+		init_mpc_region_override(&override);
+
+		override.start_address = memory_regions.secondary_partition_base;
+#ifdef NRF_NS_STORAGE_PARTITION_START
+		/* If there is a non-secure storage partition, the secondary partition
+		 * limit is the start of the non-secure storage partition.
+		 */
+		override.endaddr = memory_regions.secondary_partition_limit;
+#else
+		override.endaddr = NRF_UICR_S_BASE;
+#endif
+		override.index = index_mpc00++;
+
+		mpc_configure_override(NRF_MPC00, &override);
+	}
+#endif /* NRF_NS_SECONDARY */
+
+#ifdef NRF_NS_STORAGE_PARTITION_START
+	{
+		struct mpc_region_override override;
+
+		init_mpc_region_override(&override);
+
+		override.start_address = memory_regions.non_secure_storage_partition_base;
 		override.endaddr = NRF_UICR_S_BASE;
 		override.index = index_mpc00++;
 
 		mpc_configure_override(NRF_MPC00, &override);
 	}
+#endif /* NRF_NS_STORAGE_PARTITION_START */
 
 	/* Configure the non-secure partition of the volatile memory */
 	{

--- a/platform/ext/target/nordic_nrf/common/nrf7120/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/config.cmake
@@ -9,5 +9,4 @@
 include(${PLATFORM_PATH}/common/core/config.cmake)
 
 set(BL2                                 OFF        CACHE BOOL      "Whether to build BL2" FORCE)
-set(NRF_NS_SECONDARY                    OFF        CACHE BOOL      "Enable non-secure secondary partition" FORCE)
 set(NRF_SECURE_UART_INSTANCE            21         CACHE STRING    "The UART instance number to use for secure UART" FORCE)

--- a/platform/ext/target/nordic_nrf/common/nrf7120/partition/flash_layout.h
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/partition/flash_layout.h
@@ -23,20 +23,20 @@
 
 /* Flash layout on NRF7120 Application MCU without BL2:
  *
- * 0x0000_0000 Secure image primary (512 KiB)
- * 0x0008_0000 Protected Storage Area (16 KiB)
- * 0x0008_4000 Internal Trusted Storage Area (16 KiB)
- * 0x0008_8000 OTP / NV counters area (8 KiB)
- * 0x0008_A000 Non-secure image primary (844 KiB)
- * 0x0015_D000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
- *             otherwise unused (32 KiB)
+ * 0x0000_0000 Secure image primary (192 KB)
+ * 0x0003_0000 Protected Storage Area (16 KB)
+ * 0x0003_4000 Internal Trusted Storage Area (16 KB)
+ * 0x0003_8000 OTP / NV counters area (8 KB)
+ * 0x0003_A000 Non-secure image primary (3780 KB)
+ * 0x003E_B000 Non-secure storage, used when built with NRF_NS_STORAGE=ON,
+ *             otherwise unused (64 KB)
  *
  * RAM layout on nRF7120 Application MCU (1016 KiB M33 SRAM):
  *
- * 0x2000_0000 Secure RAM (128 KiB)
- * 0x2002_0000 Non-secure RAM (888 KiB, remainder of TOTAL_RAM_SIZE)
+ * 0x2000_0000 Secure RAM (96 KiB)
+ * 0x2001_8000 Non-secure RAM (920 KiB, remainder of TOTAL_RAM_SIZE)
  *
- * Secure RAM is kept to 128 KiB so the non-secure application (Wi-Fi stack)
+ * Secure RAM is kept to 96 KiB so the non-secure application (Wi-Fi stack)
  * gets as much of the M33 SRAM map as TF-M can grant.
  */
 
@@ -50,18 +50,16 @@
 /* Use Flash memory to store Code data */
 #define FLASH_BASE_ADDRESS                  (0x0)
 
-/* nRF7120 has 4084 KiB of non volatile memory (MRAM) but the last 116KiB are reserved
- * for FLPR MCU in Zephyr. For simplicity and for possible support for running FLPR along
- * with TF-M later FLPR non volatile memory is not used by TF-M. */
-#define FLASH_TOTAL_SIZE                    (0x3E0000)         /* 3968 KiB since the last 116 KiB are reserved for FLPR */
+/* nRF7120 has 4076 KiB of non volatile memory (MRAM). */
+#define FLASH_TOTAL_SIZE                    (0x3FB000)
 #define TOTAL_ROM_SIZE                       FLASH_TOTAL_SIZE
 
 /* Default RAM Layout on nRF7120 Application MCU without FLPR:
  *
- * 0x2000_0000 Secure data in RAM_00 (128 KiB)
- * 0x2002_0000 Non-secure data (888 KiB, remainder of TOTAL_RAM_SIZE)
+ * 0x2000_0000 Secure data in RAM_00 (96 KiB)
+ * 0x2001_8000 Non-secure data (920 KiB, remainder of TOTAL_RAM_SIZE)
  * Dissection of Non-secure RAM macro:
- * 0x2002_0000 Non-secure data in RAM_00 (384 KiB)
+ * 0x2001_8000 Non-secure data in RAM_00 (416 KiB)
  * 0x2008_0000 Non-secure data in RAM_01 (256 KiB)
  * 0x200C_0000 Non-secure data in RAM_02 (128 KiB)
  * 0x200E_0000 Non-secure data in RAM_03 (120 KiB)
@@ -71,13 +69,15 @@
  * nRF7120 has 1016 KiB of volatile memory (SRAM) available for Arm Cortex-M33,
  * which is split into 4 RAM areas. RAM allocation for FLPR core is not considered
  * for default case therefore all RAM are allocated to Arm Cortex-M33 in here.
+ *
+ * Use SRAM memory to store RW data
  */
 #define SRAM_BASE_ADDRESS                   (0x20000000)
 #define TOTAL_RAM_SIZE                      (0x000FE000)       /* 1016 KiB, since other 8 KiB from 1024 KiB are reserved for KMU exchange area */
-#define S_RAM_PARTITION_SIZE                (0x20000)          /* 128 KiB secure RAM */
+#define S_RAM_PARTITION_SIZE                (0x18000)          /* 96 KiB secure RAM */
 
-#define FLASH_S_PARTITION_SIZE                (0x80000)       /* S partition: 512 KiB*/
-#define FLASH_NS_PARTITION_SIZE               (0xD3000)       /* NS partition: 844 KiB*/
+#define FLASH_S_PARTITION_SIZE                (0x30000)        /* S partition: 192 KiB*/
+#define FLASH_NS_PARTITION_SIZE               (0x3B1000)       /* NS partition: 3780 KiB*/
 
 #define S_ROM_ALIAS_BASE   FLASH_BASE_ADDRESS
 #define NS_ROM_ALIAS_BASE  FLASH_BASE_ADDRESS


### PR DESCRIPTION
Remove NRF_NS_SECONDARY force OFF flag. MPC configure non-secure for secondary slot, WiFi patch area and NS storage area.
Rearrange flash layout algins to latest update to soc/nrf7120/nrf7120_cpuapp_ns_partition.dtsi

manifest-pr-skip