### PR TITLE
[nrf fromtree] platform: ext: nordic: integrate nrfx 4.5.0

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/core/config.cmake
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 
 set(HAL_NORDIC_PATH "DOWNLOAD" CACHE PATH "Path to the Nordic HAL (or DOWNLOAD to fetch automatically)")
-set(HAL_NORDIC_VERSION "nrfx-4.2.1" CACHE STRING "Version of the Nordic HAL to download")
+set(HAL_NORDIC_VERSION "nrfx-4.4.0" CACHE STRING "Version of the Nordic HAL to download")
 set(HAL_NORDIC_REMOTE "https://github.com/zephyrproject-rtos/hal_nordic" CACHE STRING "Remote of the Nordic HAL to download")
 # Set to FALSE if HAL_NORDIC_VERSION is a SHA.
 set(HAL_NORDIC_SHALLOW_FETCH CACHE BOOL TRUE "Use shallow fetch to download Nordic HAL.")

--- a/platform/ext/target/nordic_nrf/common/core/config.cmake
+++ b/platform/ext/target/nordic_nrf/common/core/config.cmake
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 
 set(HAL_NORDIC_PATH "DOWNLOAD" CACHE PATH "Path to the Nordic HAL (or DOWNLOAD to fetch automatically)")
-set(HAL_NORDIC_VERSION "nrfx-4.4.0" CACHE STRING "Version of the Nordic HAL to download")
+set(HAL_NORDIC_VERSION "nrfx-4.5.0" CACHE STRING "Version of the Nordic HAL to download")
 set(HAL_NORDIC_REMOTE "https://github.com/zephyrproject-rtos/hal_nordic" CACHE STRING "Remote of the Nordic HAL to download")
 # Set to FALSE if HAL_NORDIC_VERSION is a SHA.
 set(HAL_NORDIC_SHALLOW_FETCH CACHE BOOL TRUE "Use shallow fetch to download Nordic HAL.")

--- a/platform/ext/target/nordic_nrf/common/nrf7120/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/nrf7120_enga/system_nrf7120_enga.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/system_nrf71.c
         ./nrf71_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf7120/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/nrf7120_enga/system_nrf7120_enga.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf71/system_nrf71.c
 )
 
 target_compile_definitions(platform_ns


### PR DESCRIPTION
MDK 9.0.2 relocates system file for nRF71 device. Align paths.

Change-Id: I9fdb5e5b6c6b22195ba927c2c42ab276995834f0

---

PR opened for CI purposes for now. Will get upstreamed once nrfx 4.5.0 is officially released

manifest-pr-skip