### PR TITLE
[nrf fromtree] platform: nordic_nrf: apply nRF7120 RAM retention directly

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -184,12 +184,17 @@ if(SOC_NRF7120_TFM_MRAMC_SERVICE)
     )
 endif()
 
-# RAM-control service (set by zephyr's -DNRF_RAM_CTRL_SERVICE=ON).
-if(NRF_RAM_CTRL_SERVICE)
+# nRF7120 disables RAM retention during secure startup. Other platforms need
+# the helper only when the RAM-control service is enabled.
+if(NRF_RAM_CTRL_SERVICE OR target STREQUAL "nrf7120")
     target_sources(platform_s
         PRIVATE
             ${HAL_NORDIC_PATH}/nrfx/helpers/nrfx_ram_ctrl.c
     )
+endif()
+
+# RAM-control service (set by zephyr's -DNRF_RAM_CTRL_SERVICE=ON).
+if(NRF_RAM_CTRL_SERVICE)
     target_compile_definitions(platform_s
         PUBLIC
             TFM_NRF_RAM_CTRL_SERVICE

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -102,7 +102,7 @@ struct tfm_mramc_set_wen_service_args_t {
 };
 #endif
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE) || defined(TFM_NRF_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE) || defined(TFM_NRF_RAM_CTRL_SERVICE)
 /** @brief RAM-control operation selector. */
 enum tfm_ram_ctrl_op {
 	/** System ON power (MEMCONF CONTROL), applied immediately. */
@@ -222,7 +222,7 @@ enum tfm_platform_err_t tfm_platform_mramc_init(void);
 enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode);
 #endif /* SOC_NRF7120_TFM_MRAMC_SERVICE */
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 /**
  * @brief Power up/down a non-secure RAM range in System ON (MEMCONF CONTROL).
  *

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -107,9 +107,9 @@ struct tfm_mramc_set_wen_service_args_t {
 enum tfm_ram_ctrl_op {
 	/** System ON power (MEMCONF CONTROL), applied immediately. */
 	TFM_RAM_CTRL_OP_POWER,
-	/** System OFF retention (MEMCONF RET), recorded in the secure cache. */
+	/** System OFF retention (MEMCONF RET), applied immediately. */
 	TFM_RAM_CTRL_OP_RETAIN,
-	/** Read back CONTROL/RET/RET2 and the cached retention plan. */
+	/** Read back CONTROL/RET/RET2. */
 	TFM_RAM_CTRL_OP_READ_STATUS,
 };
 
@@ -127,7 +127,6 @@ struct tfm_ram_ctrl_service_out_t {
 	uint32_t control;     /* MEMCONF POWER[0].CONTROL snapshot (read status) */
 	uint32_t ret;         /* MEMCONF POWER[0].RET snapshot (read status) */
 	uint32_t ret2;        /* MEMCONF POWER[0].RET2 snapshot (read status) */
-	uint32_t ret_planned; /* cached mask of 32 KiB sections to retain at OFF (read status) */
 };
 #endif
 
@@ -238,7 +237,7 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_power_set(uint32_t addr, uint32_t 
 /**
  * @brief Mark/unmark a non-secure RAM range for retention across System OFF.
  *
- * Recorded in the secure domain; applied when the system enters System OFF.
+ * Applied immediately in the secure domain.
  *
  * @param addr  Start address of the range (must be within non-secure RAM).
  * @param len   Length of the range in bytes.
@@ -249,17 +248,15 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_power_set(uint32_t addr, uint32_t 
 enum tfm_platform_err_t tfm_platform_ram_ctrl_retention_set(uint32_t addr, uint32_t len, bool on);
 
 /**
- * @brief Read back MEMCONF POWER[0] CONTROL/RET/RET2 and the cached retention plan.
+ * @brief Read back MEMCONF POWER[0] CONTROL/RET/RET2.
  *
  * @param control      MEMCONF POWER[0].CONTROL value (may be NULL).
  * @param ret          MEMCONF POWER[0].RET value (may be NULL).
  * @param ret2         MEMCONF POWER[0].RET2 value (may be NULL).
- * @param ret_planned  Cached mask of 32 KiB sections to retain at OFF (may be NULL).
- *
  * @return Values as specified by \ref tfm_platform_err_t.
  */
 enum tfm_platform_err_t tfm_platform_ram_ctrl_read_status(uint32_t *control, uint32_t *ret,
-							  uint32_t *ret2, uint32_t *ret_planned);
+							  uint32_t *ret2);
 #endif /* NRF_TFM_RAM_CTRL_SERVICE */
 
 #if defined(CONFIG_NRF_WIFI_KMU)

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -150,7 +150,7 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_retention_set(uint32_t addr, uint3
 }
 
 enum tfm_platform_err_t tfm_platform_ram_ctrl_read_status(uint32_t *control, uint32_t *ret,
-							  uint32_t *ret2, uint32_t *ret_planned)
+							  uint32_t *ret2)
 {
 	enum tfm_platform_err_t err;
 	psa_invec in_vec;
@@ -178,9 +178,6 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_read_status(uint32_t *control, uin
 	}
 	if (ret2 != NULL) {
 		*ret2 = out.ret2;
-	}
-	if (ret_planned != NULL) {
-		*ret_planned = out.ret_planned;
 	}
 
 	return err;

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -118,7 +118,7 @@ enum tfm_platform_err_t tfm_platform_mramc_set_wen(uint32_t write_mode)
 }
 #endif
 
-#if defined(CONFIG_NRF_TFM_RAM_CTRL_SERVICE)
+#if defined(CONFIG_SOC_SERIES_NRF71_TFM_RAM_CTRL_SERVICE)
 static enum tfm_platform_err_t ram_ctrl_set(uint32_t op, uint32_t addr, uint32_t len, bool on)
 {
 	psa_invec in_vec;

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -285,15 +285,12 @@ enum tfm_platform_err_t tfm_platform_hal_mramc_set_wen_service(const psa_invec *
 
 #if TFM_NRF_RAM_CTRL_SERVICE
 
-/* RAM section granularity for the retention cache (32 KiB on nRF54L / nRF7120). */
+/* RAM section granularity (32 KiB on nRF54L / nRF7120). */
 #define RAM_CTRL_SECTION_SIZE 0x8000U
 
 /* Align a RAM address down/up to the section granularity (power-of-two size). */
 #define RAM_CTRL_SECTION_DOWN(x) ((x) & ~(RAM_CTRL_SECTION_SIZE - 1U))
 #define RAM_CTRL_SECTION_UP(x)   RAM_CTRL_SECTION_DOWN((x) + (RAM_CTRL_SECTION_SIZE - 1U))
-
-/* Mask of 32 KiB RAM sections to retain at System OFF (bit i => POWER[0] section i). */
-static uint32_t s_ret_section_mask;
 
 /* True if [addr, addr+len) lies entirely within the non-secure RAM window. */
 static bool ram_ctrl_range_is_ns(uint32_t addr, uint32_t len)
@@ -303,28 +300,6 @@ static bool ram_ctrl_range_is_ns(uint32_t addr, uint32_t len)
 	}
 
 	return (addr >= NS_DATA_START) && ((addr + len - 1U) <= NS_DATA_LIMIT);
-}
-
-static uint32_t ram_ctrl_range_to_section_mask(uint32_t addr, uint32_t len)
-{
-	uint32_t first, last, count;
-
-	if (len == 0U || addr < NRF_MEMORY_RAM_BASE) {
-		return 0U;
-	}
-
-	first = (addr - NRF_MEMORY_RAM_BASE) / RAM_CTRL_SECTION_SIZE;
-	last = (addr + len - 1U - NRF_MEMORY_RAM_BASE) / RAM_CTRL_SECTION_SIZE;
-	if (last > 31U) {
-		return 0U;
-	}
-
-	count = last - first + 1U;
-	if (count >= 32U) {
-		return 0xFFFFFFFFU;
-	}
-
-	return ((1U << count) - 1U) << first;
 }
 
 enum tfm_platform_err_t
@@ -344,14 +319,12 @@ tfm_platform_hal_ram_ctrl_service(const psa_invec *in_vec, const psa_outvec *out
 	out->control = 0;
 	out->ret = 0;
 	out->ret2 = 0;
-	out->ret_planned = 0;
 
-	/* Read back MEMCONF registers + the cached retention plan. */
+	/* Read back MEMCONF registers. */
 	if (args->op == TFM_RAM_CTRL_OP_READ_STATUS) {
 		out->control = NRF_MEMCONF->POWER[0].CONTROL;
 		out->ret = NRF_MEMCONF->POWER[0].RET;
 		out->ret2 = NRF_MEMCONF->POWER[0].RET2;
-		out->ret_planned = s_ret_section_mask;
 		out->result = 0;
 		return TFM_PLATFORM_ERR_SUCCESS;
 	}
@@ -378,14 +351,21 @@ tfm_platform_hal_ram_ctrl_service(const psa_invec *in_vec, const psa_outvec *out
 		break;
 	}
 	case TFM_RAM_CTRL_OP_RETAIN: {
-		/* Record in the secure cache; applied at System OFF. */
-		uint32_t m = ram_ctrl_range_to_section_mask(args->addr, args->len);
+		/* RET is controlled per 32 KiB section. Reject requests whose
+		 * containing sections overlap memory outside the non-secure window
+		 * instead of silently applying only part of the requested range.
+		 */
+		uint32_t start = RAM_CTRL_SECTION_DOWN(args->addr);
+		uint32_t end = RAM_CTRL_SECTION_UP(args->addr + args->len);
+		uint32_t ns_lo = RAM_CTRL_SECTION_UP((uint32_t)NS_DATA_START);
+		uint32_t ns_hi = RAM_CTRL_SECTION_DOWN((uint32_t)NS_DATA_LIMIT + 1U);
 
-		if (args->on != 0U) {
-			s_ret_section_mask |= m;
-		} else {
-			s_ret_section_mask &= ~m;
+		if (start < ns_lo || end > ns_hi || start >= end) {
+			return TFM_PLATFORM_ERR_INVALID_PARAM;
 		}
+
+		nrfx_ram_ctrl_retention_enable_set((void *)(uintptr_t)start,
+					       end - start, args->on != 0U);
 		break;
 	}
 	default:

--- a/platform/ext/target/nordic_nrf/common/nrf7120/nrf71_init.c
+++ b/platform/ext/target/nordic_nrf/common/nrf7120/nrf71_init.c
@@ -6,6 +6,7 @@
  */
 #include <stdint.h>
 #include <nrfx.h>
+#include <helpers/nrfx_ram_ctrl.h>
 
 #ifndef BIT_MASK
 /* Use Zephyr BIT_MASK for unasigned integers */
@@ -45,6 +46,8 @@ void __attribute__((weak)) wifi_setup(void){
 #endif
 
 int  __attribute__((weak)) soc_early_init_hook(void){
+    nrfx_ram_ctrl_retention_enable_all_set(false);
+
 	/* Update the SystemCoreClock global variable with current core clock
 	 * retrieved from hardware state.
 	 */


### PR DESCRIPTION
This PR brings the upstream changes to the `sdk-trusted-firmware-m`
Changes can be seen at https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/52584

Scope of the changes basically
- Previously ram-retention for system-off was clear at the `system-off` phase and then reenabled for the regions defined in the device tree file. Instead of that, ram-retention cleared at the beginning of the application. This allow developers to have configure ram-retention with run-time APIs.
- Previously system-off ram retention requests were cached and applied later. Instead of that, applied directly.

manifest-pr-skip