### PR TITLE
[nrf fromtree] platform: nordic_nrf: nrf7120: Add TF-M implementation for Wi-Fi KMU library.

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/core/CMakeLists.txt
@@ -196,6 +196,17 @@ if(NRF_RAM_CTRL_SERVICE)
     )
 endif()
 
+if(CONFIG_NRF_WIFI_KMU)
+    target_sources(platform_s
+        PRIVATE
+            ${ZEPHYR_NRF_MODULE_DIR}/lib/wifi_kmu/wifi_kmu.c
+    )
+    target_compile_definitions(platform_s
+        PUBLIC
+            CONFIG_NRF_WIFI_KMU=1
+    )
+endif()
+
 target_compile_options(platform_s
     PUBLIC
         ${COMPILER_CMSE_FLAG}

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_ioctl_core_api.h
@@ -36,6 +36,8 @@ enum tfm_platform_ioctl_core_reqest_types_t {
 	TFM_PLATFORM_IOCTL_MRAMC_INIT_SERVICE,
 	TFM_PLATFORM_IOCTL_MRAMC_SET_WEN_SERVICE,
 	TFM_PLATFORM_IOCTL_RAM_CTRL_SERVICE,
+	TFM_PLATFORM_IOCTL_WIFI_KMU_WRITE_KEY_SERVICE,
+	TFM_PLATFORM_IOCTL_WIFI_KMU_ERASE_KEYS_SERVICE,
 	/* Last core service, start platform specific from this value. */
 	TFM_PLATFORM_IOCTL_CORE_LAST
 };
@@ -128,6 +130,16 @@ struct tfm_ram_ctrl_service_out_t {
 	uint32_t ret_planned; /* cached mask of 32 KiB sections to retain at OFF (read status) */
 };
 #endif
+
+#if defined(CONFIG_NRF_WIFI_KMU)
+/** @brief Argument list for Wi-Fi KMU write key service */
+struct tfm_wifi_kmu_write_key_service_args_t {
+	uint32_t slot_id;
+	uint32_t target_addr;
+	const uint8_t *key_buffer;
+	size_t key_size;
+};
+#endif /* CONFIG_NRF_WIFI_KMU */
 
 /**
  * @brief Perform a read operation.
@@ -249,6 +261,28 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_retention_set(uint32_t addr, uint3
 enum tfm_platform_err_t tfm_platform_ram_ctrl_read_status(uint32_t *control, uint32_t *ret,
 							  uint32_t *ret2, uint32_t *ret_planned);
 #endif /* NRF_TFM_RAM_CTRL_SERVICE */
+
+#if defined(CONFIG_NRF_WIFI_KMU)
+/**
+ * @brief Write key to Wi-Fi secure RAM via KMU.
+ *
+ * @param[in] slot_id      Starting KMU slot ID.
+ * @param[in] target_addr  Address in Wi-Fi secure RAM.
+ * @param[in] key_buffer   Buffer containing key.
+ * @param[in] key_size     Size of key buffer in bytes.
+ *
+ * @return Values as specified by \ref tfm_platform_err_t.
+ */
+enum tfm_platform_err_t tfm_platform_wifi_kmu_write_key(uint32_t slot_id, uint32_t target_addr,
+							const uint8_t *key_buffer, size_t key_size);
+
+/**
+ * @brief Erase all KMU slots used by Wi-Fi keys.
+ *
+ * @return Values as specified by \ref tfm_platform_err_t.
+ */
+enum tfm_platform_err_t tfm_platform_wifi_kmu_erase_keys(void);
+#endif /* CONFIG_NRF_WIFI_KMU */
 
 #ifdef __cplusplus
 }

--- a/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
+++ b/platform/ext/target/nordic_nrf/common/core/services/include/tfm_platform_hal_ioctl.h
@@ -40,6 +40,12 @@ tfm_platform_hal_mramc_set_wen_service(const psa_invec *in_vec);
 enum tfm_platform_err_t
 tfm_platform_hal_ram_ctrl_service(const psa_invec *in_vec, const psa_outvec *out_vec);
 
+enum tfm_platform_err_t
+tfm_platform_hal_wifi_kmu_write_key_service(const psa_invec *in_vec);
+
+enum tfm_platform_err_t
+tfm_platform_hal_wifi_kmu_erase_keys_service(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_ioctl_core_ns_api.c
@@ -186,3 +186,27 @@ enum tfm_platform_err_t tfm_platform_ram_ctrl_read_status(uint32_t *control, uin
 	return err;
 }
 #endif /* NRF_TFM_RAM_CTRL_SERVICE */
+
+#if defined(CONFIG_NRF_WIFI_KMU)
+enum tfm_platform_err_t tfm_platform_wifi_kmu_write_key(uint32_t slot_id, uint32_t target_addr,
+							const uint8_t *key_buffer, size_t key_size)
+{
+	psa_invec in_vec;
+	struct tfm_wifi_kmu_write_key_service_args_t args;
+
+	args.slot_id = slot_id;
+	args.target_addr = target_addr;
+	args.key_buffer = key_buffer;
+	args.key_size = key_size;
+
+	in_vec.base = (const void *)&args;
+	in_vec.len = sizeof args;
+
+	return tfm_platform_ioctl(TFM_PLATFORM_IOCTL_WIFI_KMU_WRITE_KEY_SERVICE, &in_vec, NULL);
+}
+
+enum tfm_platform_err_t tfm_platform_wifi_kmu_erase_keys(void)
+{
+	return tfm_platform_ioctl(TFM_PLATFORM_IOCTL_WIFI_KMU_ERASE_KEYS_SERVICE, NULL, NULL);
+}
+#endif /* CONFIG_NRF_WIFI_KMU */

--- a/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
+++ b/platform/ext/target/nordic_nrf/common/core/services/src/tfm_platform_hal_ioctl.c
@@ -32,6 +32,10 @@
 #include "region_defs.h"
 #endif
 
+#if CONFIG_NRF_WIFI_KMU
+#include <wifi_kmu/wifi_kmu.h>
+#endif
+
 #include "handle_attr.h"
 
 enum tfm_platform_err_t
@@ -392,3 +396,28 @@ tfm_platform_hal_ram_ctrl_service(const psa_invec *in_vec, const psa_outvec *out
 	return TFM_PLATFORM_ERR_SUCCESS;
 }
 #endif /* TFM_NRF_RAM_CTRL_SERVICE */
+
+#if CONFIG_NRF_WIFI_KMU
+enum tfm_platform_err_t tfm_platform_hal_wifi_kmu_write_key_service(const psa_invec *in_vec)
+{
+	struct tfm_wifi_kmu_write_key_service_args_t *args;
+	int err;
+
+	if (in_vec->len != sizeof *args) {
+		return TFM_PLATFORM_ERR_INVALID_PARAM;
+	}
+
+	args = (struct tfm_wifi_kmu_write_key_service_args_t *)in_vec->base;
+	err = wifi_kmu_write_key(args->slot_id, args->target_addr, args->key_buffer,
+				 args->key_size);
+
+	return err ? TFM_PLATFORM_ERR_SYSTEM_ERROR : TFM_PLATFORM_ERR_SUCCESS;
+}
+
+enum tfm_platform_err_t tfm_platform_hal_wifi_kmu_erase_keys_service(void)
+{
+	int err = wifi_kmu_erase_keys();
+
+	return err ? TFM_PLATFORM_ERR_SYSTEM_ERROR : TFM_PLATFORM_ERR_SUCCESS;
+}
+#endif /* CONFIG_NRF_WIFI_KMU */


### PR DESCRIPTION
Allows ns firmware to write Wi-Fi keys.

Change-Id: I5b2bdb9eb9a78acb88ba64a3c983757070e915bd

(cherry picked from commit 182e9dae760762372c8092a03a0c40f8bbd493f5)