### PR TITLE
[nrf noup] platform: nordic_nrf: nrf54lc10a: Fix system file path

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf54lc10a/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lc10a/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lc10a/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lc10a/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns


### PR DESCRIPTION
The `nrf54lc10a` platform added in #260 points at the pre-Split-MDK
location of `system_nrf54l.c`:

```
${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
```

That file no longer exists in the `hal_nordic` revision NCS pins, so both
the secure and the non-secure build fail to configure:

```
CMake Error at .../nrf54lc10a/CMakeLists.txt:29 (target_sources):
  Cannot find source file:
    .../nrfx/bsp/stable/mdk/system_nrf54l.c
```

Every other `nordic_nrf` platform in this repository already uses the
`nrf54l/` subdirectory; this aligns `nrf54lc10a` (secure and non-secure)
with them.

## Test

Built and ran on nRF54LC10A DK hardware with the fix applied:

- `samples/tfm/tfm_hello_world` for `nrf54lc10dk/nrf54lc10a/cpuapp/ns` — builds, boots, TF-M secure log and NS console both output as expected.
- `samples/crypto/aes_cbc` for `nrf54lc10dk/nrf54lc10a/cpuapp/ns` — builds, runs, all operations pass.

Without the fix, both fail at CMake configure time.