### PR TITLE
[nrf fromtree] platform: nordic_nrf: nrf54lc10: align system file pat…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/nrf54lc10a/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lc10a/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 target_sources(platform_s
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
         ../nrf54l/nrf54l_init.c
 )
 

--- a/platform/ext/target/nordic_nrf/common/nrf54lc10a/ns/CMakeLists.txt
+++ b/platform/ext/target/nordic_nrf/common/nrf54lc10a/ns/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(platform_ns
 
 target_sources(platform_ns
     PRIVATE
-        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/system_nrf54l.c
+        ${HAL_NORDIC_PATH}/nrfx/bsp/stable/mdk/nrf54l/system_nrf54l.c
 )
 
 target_compile_definitions(platform_ns


### PR DESCRIPTION

I unfortunately clobbered this. I don't know if re-apply is the correct way of handling it. If we do re-apply or do a no-up. It gets a bit messy doing a re-apply.

>…hs to Split MDK
>
>Split MDK introduces individual per-device directories. Align paths to new structure.
>
>Change-Id: I399d37174d67ec20a24a545c08a818225e36e057
>
>(cherry picked from commit e75cf4bc50e0f225ed05076f9b74f76611255afa)


manifest-pr-skip

manifest pr: https://github.com/nrfconnect/sdk-nrf/pull/29861