### PR TITLE
[nrf fromtree dirty] platform: nordic_nrf: Add SPDX tags to device_cfg.h files

### DIFF
--- a/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf5340dk_nrf5340_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54l15dk_nrf54l10_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54l15dk_nrf54l10_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54l15dk_nrf54l15_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54l15dk_nrf54l15_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54lc10dk_nrf54lc10a_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54lc10dk_nrf54lc10a_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20a_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20a_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54lm20dk_nrf54lm20b_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf54lv10dk_nrf54lv10a_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf54lv10dk_nrf54lv10a_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf7120dk_nrf7120_cpuapp/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf7120dk_nrf7120_cpuapp/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/device_cfg.h
+++ b/platform/ext/target/nordic_nrf/nrf9160dk_nrf9160/device_cfg.h
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2016-2019 ARM Limited
  *
+ * SPDX-License-Identifier: Apache-2.0
+ *
  * Licensed under the Apache License Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at


### PR DESCRIPTION
> The Apache-2.0 notice in these files is missing the punctuation of the standard boilerplate, so license scanners cannot match it by full text, and there is no SPDX tag to fall back on. Tools consequently report the files as carrying no license at all.
> 
> Add an SPDX-License-Identifier tag stating the license each notice already grants. This follows nrf9161dk_nrf9161, previously the only Nordic board whose device_cfg.h carried a tag. The notice text itself is left untouched.
> 
> All ten remaining Nordic device_cfg.h files share the same ARM header and are covered here, so a newly added board no longer reintroduces the problem.
> 
> Change-Id: Ifc30600d7e9a8a9801190a63c2266e4a9d37e970
> 
> (cherry picked from commit 717da8af8f955b6aa745b95e363c815f8b83a43c)

This now also adds

> [nrf fromtree] platform: nordic_nrf: add nRF7120e soc support
> Add support for nrf7120e SoC. The variant shares startup code and
> peripheral configuration with nRF7120.
> 
> Change-Id: Ib81da99b1f5f76145ef97945494f3d40c18a30f2
> Signed-off-by: Robert Robinson <robert.robinson@nordicsemi.no>
> Assisted-by: Cursor:Auto
> (cherry picked from commit 885ecd136ddad15709103d4d4e0a03b34488bd92)

To avoid cherry-pick conflict.

Also adds 2 commits from https://github.com/nrfconnect/sdk-trusted-firmware-m/pull/263