### PR TITLE
[nrf fromtree] platform: nordic_nrf: Fix SAU region limit off by one

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_54l.c
@@ -186,7 +186,7 @@ void sau_and_idau_cfg(void)
 	   non-secure NVM and before the UICR.*/
 	SAU->RNR = 0;
 	SAU->RBAR = (memory_regions.non_secure_partition_base & SAU_RBAR_BADDR_Msk);
-	SAU->RLAR = (NRF_UICR_S_BASE & SAU_RLAR_LADDR_Msk) | SAU_RLAR_ENABLE_Msk;
+	SAU->RLAR = ((NRF_UICR_S_BASE - 1) & SAU_RLAR_LADDR_Msk) | SAU_RLAR_ENABLE_Msk;
 
 	/* Leave SAU region 1 disabled until we find a use for it */
 

--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -157,7 +157,7 @@ void sau_and_idau_cfg(void)
 	   non-secure NVM and before the UICR.*/
 	SAU->RNR = 0;
 	SAU->RBAR = (memory_regions.non_secure_partition_base & SAU_RBAR_BADDR_Msk);
-	SAU->RLAR = (NRF_UICR_S_BASE & SAU_RLAR_LADDR_Msk) | SAU_RLAR_ENABLE_Msk;
+	SAU->RLAR = ((NRF_UICR_S_BASE - 1) & SAU_RLAR_LADDR_Msk) | SAU_RLAR_ENABLE_Msk;
 
 	/* Leave SAU region 1 disabled until we find a use for it */
 


### PR DESCRIPTION
Cherry-pick of the pending upstream change.

The SAU region limit is inclusive and 32-byte aligned, so using the UICR base as the limit makes the region cover the first 32 bytes of the UICR, which is where `UICR.APPROTECT` lives. Use the last address before the UICR instead.

Upstream PR: https://review.trustedfirmware.org/c/TF-M/trusted-firmware-m/+/53351

Verified on an nRF54L15 DK: a secure read of `0x00FFD000` goes from a precise BusFault (`BFAR = 0x00FFD000`) to returning `0xFFFFFFFF`, and a non-secure read raises a SecureFault instead of a BusFault, confirming the address is now attributed secure.

The nRF71 line is textually identical and fixed here too, but has not been exercised on nRF71 hardware.