### PR TITLE
[nrf fromlist] platform: nordic_nrf: lock unused MPC03 overrides on M…

### DIFF
--- a/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
+++ b/platform/ext/target/nordic_nrf/common/core/target_cfg_71.c
@@ -320,7 +320,7 @@ enum tfm_plat_err_t nrf_mpc_init_cfg(void)
 
 		override.index = index_mpc03++;
 
-		mpc_configure_override(NRF_MPC00, &override);
+		mpc_configure_override(NRF_MPC03, &override);
 	}
 
 	return TFM_PLAT_ERR_SUCCESS;


### PR DESCRIPTION
…PC03

The loop that locks and disables the unused overrides of MPC03 walks index_mpc03 but passes NRF_MPC00 to mpc_configure_override(). Two things follow. MPC03's unused overrides are never locked, so they remain available to be configured later. And MPC00's overrides at those indices are rewritten with enable cleared, which covers the override configured for the non-secure volatile memory; that write is ignored today only because init_mpc_region_override() sets lock, so the earlier configuration can no longer be modified.

Pass NRF_MPC03, matching the index counter and the comment above it.

Change-Id: I1c80f4fd256ee73a39280e0c3a9c50330f62df68